### PR TITLE
Bumped version of generic worker to 5.0.0

### DIFF
--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -354,7 +354,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v3.0.0alpha1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -424,7 +424,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 3.0.0alpha1"
+            "Match": "generic-worker 5.0.0"
           }
         ]
       }

--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -932,7 +932,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v3.0.0alpha1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1002,7 +1002,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 3.0.0alpha1"
+            "Match": "generic-worker 5.0.0"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -349,7 +349,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v3.0.0alpha1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -419,7 +419,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 3.0.0alpha1"
+            "Match": "generic-worker 5.0.0"
           }
         ]
       }


### PR DESCRIPTION
This provides new features:
* One livelog instead of one per command, named same as docker-worker log file
* Worker type metadata now logged at start of log file
* Exit code of processes logged in log file
* Total task execution time logged in log file