### PR TITLE
Added eu-central-1 region

### DIFF
--- a/ci/update-workertype.sh
+++ b/ci/update-workertype.sh
@@ -14,11 +14,7 @@ export AWS_SECRET_ACCESS_KEY=${TASKCLUSTER_AWS_SECRET_KEY}
 : ${aws_tc_account_id:?"aws_tc_account_id is not set"}
 
 aws_region=${aws_region:='us-west-2'}
-aws_copy_regions[0]='us-east-1'
-aws_copy_regions[1]='us-west-1'
-aws_regions[0]=${aws_region}
-aws_regions[1]=${aws_copy_regions[0]}
-aws_regions[2]=${aws_copy_regions[1]}
+aws_copy_regions=('us-east-1' 'us-west-1' 'eu-central-1')
 
 if [ "${#}" -lt 1 ]; then
   echo "workertype argument missing; usage: ./update-workertype.sh workertype" >&2


### PR DESCRIPTION
@grenade Note, you'll probably need to update the worker type definitions first to point to some other AMI in `eu-central-1`, so that when `update_workertype.sh` runs, it has something to update with the new AMI in that region...

Note I dropped `aws_regions` as I couldn't see it being used somewhere - let me know if this is ok.