### PR TITLE
Upgraded generic worker to version 5.0.1

### DIFF
--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -354,7 +354,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -424,7 +424,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 5.0.0"
+            "Match": "generic-worker 5.0.1"
           }
         ]
       }

--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -932,7 +932,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1002,7 +1002,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 5.0.0"
+            "Match": "generic-worker 5.0.1"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -349,7 +349,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.1/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -419,7 +419,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 5.0.0"
+            "Match": "generic-worker 5.0.1"
           }
         ]
       }


### PR DESCRIPTION
Note, I had to build gw on my mac, rather than in travis, due to gimme being broken in travis at the moment. Hope it works ok! One consequence is that it is built with go 1.6 instead of go 1.5.