### PR TITLE
Bug 1292399 - updated outdated fingerprints

### DIFF
--- a/userdata/Configuration/Mercurial/mercurial.us-east-1.ini
+++ b/userdata/Configuration/Mercurial/mercurial.us-east-1.ini
@@ -48,8 +48,8 @@ dotencode=False
 
 [hostfingerprints]
 hg.mozilla.org = af:27:b9:34:47:4e:e5:98:01:f6:83:2b:51:c9:aa:d8:df:fb:1a:27
-s3-external-1.amazonaws.com = c7:60:58:e5:d0:3f:1c:71:88:f8:e4:1b:04:05:28:0a:fb:1f:0f:40
-s3-us-west-2.amazonaws.com = 1a:0e:4a:64:90:c1:d0:2f:79:46:95:b5:17:dc:63:45:cf:19:37:bd
+s3-external-1.amazonaws.com = c0:51:d8:fa:6b:58:94:f2:3e:4e:7d:b2:36:5f:02:e4:f0:3f:54:ff
+s3-us-west-2.amazonaws.com = 9d:35:10:89:3f:58:cb:5b:7a:89:54:d2:25:9c:67:84:c4:a9:8e:01
 ftp-ssl.mozilla.org = 9d:8e:3e:7c:4a:33:6f:53:c6:64:a8:48:d3:ea:72:05:f0:73:a4:90
 
 [ui]

--- a/userdata/Configuration/Mercurial/mercurial.us-west-1.ini
+++ b/userdata/Configuration/Mercurial/mercurial.us-west-1.ini
@@ -48,8 +48,8 @@ dotencode=False
 
 [hostfingerprints]
 hg.mozilla.org = af:27:b9:34:47:4e:e5:98:01:f6:83:2b:51:c9:aa:d8:df:fb:1a:27
-s3-external-1.amazonaws.com = c7:60:58:e5:d0:3f:1c:71:88:f8:e4:1b:04:05:28:0a:fb:1f:0f:40
-s3-us-west-2.amazonaws.com = 1a:0e:4a:64:90:c1:d0:2f:79:46:95:b5:17:dc:63:45:cf:19:37:bd
+s3-external-1.amazonaws.com = c0:51:d8:fa:6b:58:94:f2:3e:4e:7d:b2:36:5f:02:e4:f0:3f:54:ff
+s3-us-west-2.amazonaws.com = 9d:35:10:89:3f:58:cb:5b:7a:89:54:d2:25:9c:67:84:c4:a9:8e:01
 ftp-ssl.mozilla.org = 9d:8e:3e:7c:4a:33:6f:53:c6:64:a8:48:d3:ea:72:05:f0:73:a4:90
 
 [ui]

--- a/userdata/Configuration/Mercurial/mercurial.us-west-2.ini
+++ b/userdata/Configuration/Mercurial/mercurial.us-west-2.ini
@@ -48,8 +48,8 @@ dotencode=False
 
 [hostfingerprints]
 hg.mozilla.org = af:27:b9:34:47:4e:e5:98:01:f6:83:2b:51:c9:aa:d8:df:fb:1a:27
-s3-external-1.amazonaws.com = c7:60:58:e5:d0:3f:1c:71:88:f8:e4:1b:04:05:28:0a:fb:1f:0f:40
-s3-us-west-2.amazonaws.com = 1a:0e:4a:64:90:c1:d0:2f:79:46:95:b5:17:dc:63:45:cf:19:37:bd
+s3-external-1.amazonaws.com = c0:51:d8:fa:6b:58:94:f2:3e:4e:7d:b2:36:5f:02:e4:f0:3f:54:ff
+s3-us-west-2.amazonaws.com = 9d:35:10:89:3f:58:cb:5b:7a:89:54:d2:25:9c:67:84:c4:a9:8e:01
 ftp-ssl.mozilla.org = 9d:8e:3e:7c:4a:33:6f:53:c6:64:a8:48:d3:ea:72:05:f0:73:a4:90
 
 [ui]


### PR DESCRIPTION
This is maybe a short/medium term fix - long term we probably want a way that fingerprint checking is either self-managing (if possible) or doesn't require new AMIs to be created when a fingerprint changes...

I'm pretty sure [bundleclone](https://www.mercurial-scm.org/wiki/BundleCloneExtension#Configuration) should be able to handle that automatically, as keys are signed by a CA, and [hg already handles such things](https://www.mercurial-scm.org/wiki/CACertificates).