### PR TITLE
Upgraded generic worker from version 5.0.1 to version 5.1.0 (gzipped log files)

### DIFF
--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -354,7 +354,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.1.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -424,7 +424,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 5.0.1"
+            "Match": "generic-worker 5.1.0"
           }
         ]
       }

--- a/userdata/Manifest/win2012.json
+++ b/userdata/Manifest/win2012.json
@@ -932,7 +932,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.1.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1002,7 +1002,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 5.0.1"
+            "Match": "generic-worker 5.1.0"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -349,7 +349,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.0.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v5.1.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -419,7 +419,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 5.0.1"
+            "Match": "generic-worker 5.1.0"
           }
         ]
       }


### PR DESCRIPTION
This picks up [bug 1291249](https://bugzilla.mozilla.org/show_bug.cgi?id=1291249) (gzipped log files).

See [changes to generic worker](https://github.com/taskcluster/generic-worker/compare/v5.0.1...v5.1.0).

The other commits just relate to getting travis making releases against since gimme tool broke.