### PR TITLE
Upgraded win test worker types to use generic worker 6.0.5 (from 6.0.4). 

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.4/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.4"
+            "Match": "generic-worker 6.0.5"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.4/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.4"
+            "Match": "generic-worker 6.0.5"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.4/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.4"
+            "Match": "generic-worker 6.0.5"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.4/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.4"
+            "Match": "generic-worker 6.0.5"
           }
         ]
       }

--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.4/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.4"
+            "Match": "generic-worker 6.0.5"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.4/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.4"
+            "Match": "generic-worker 6.0.5"
           }
         ]
       }


### PR DESCRIPTION
@grenade This new release adds some debugging for the claim-expired bug, only. So no fixes, but hopefully better debug logs...

Thanks!