### PR TITLE
Upgraded win test worker types from generic worker 6.0.5 -> 6.0.6

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.5"
+            "Match": "generic-worker 6.0.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.5"
+            "Match": "generic-worker 6.0.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.6/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.5"
+            "Match": "generic-worker 6.0.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.6/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.5"
+            "Match": "generic-worker 6.0.6"
           }
         ]
       }

--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.5"
+            "Match": "generic-worker 6.0.6"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -392,7 +392,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.5/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.0.6/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -462,7 +462,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.0.5"
+            "Match": "generic-worker 6.0.6"
           }
         ]
       }


### PR DESCRIPTION
@grenade Hope this finally fixes the claim-expired issue!