### PR TITLE
Bug 1303455 - Upgrade generic worker to v7.0.0 on win7 and win10 worker types

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -396,7 +396,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.1.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -466,7 +466,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.1.0"
+            "Match": "generic-worker 7.0.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -396,7 +396,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.1.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -466,7 +466,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.1.0"
+            "Match": "generic-worker 7.0.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -428,7 +428,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.1.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -498,7 +498,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.1.0"
+            "Match": "generic-worker 7.0.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -428,7 +428,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.1.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -498,7 +498,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.1.0"
+            "Match": "generic-worker 7.0.0"
           }
         ]
       }

--- a/userdata/Manifest/win10.json
+++ b/userdata/Manifest/win10.json
@@ -396,7 +396,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.1.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -466,7 +466,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.1.0"
+            "Match": "generic-worker 7.0.0"
           }
         ]
       }

--- a/userdata/Manifest/win7.json
+++ b/userdata/Manifest/win7.json
@@ -428,7 +428,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v6.1.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -498,7 +498,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 6.1.0"
+            "Match": "generic-worker 7.0.0"
           }
         ]
       }


### PR DESCRIPTION
Initially, just updating test environments (Windows 7, Windows 10), and if all goes ok, we can upgrade builders (manifests for `gecko-{1,2,3}-b-win2012`, `win2012`) in a separate PR.