### PR TITLE
Upgrade win7/win10 beta worker types to g-w 7.0.3alpha1

### DIFF
--- a/userdata/Configuration/SeAssignPrimaryTokenPrivilege-GW.secpol
+++ b/userdata/Configuration/SeAssignPrimaryTokenPrivilege-GW.secpol
@@ -1,5 +1,0 @@
-[Privilege Rights]
-SeCreateSymbolicLinkPrivilege = GenericWorker
-[Version]
-signature="$CHICAGO$"
-Revision=1

--- a/userdata/Configuration/SeAssignPrimaryTokenPrivilege-GW.secpol
+++ b/userdata/Configuration/SeAssignPrimaryTokenPrivilege-GW.secpol
@@ -1,0 +1,5 @@
+[Privilege Rights]
+SeCreateSymbolicLinkPrivilege = GenericWorker
+[Version]
+signature="$CHICAGO$"
+Revision=1

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -396,7 +396,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.2alpha1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.3alpha1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -466,7 +466,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.0.2alpha1"
+            "Match": "generic-worker 7.0.3alpha1"
           }
         ]
       }
@@ -706,48 +706,6 @@
         {
           "ComponentType": "CommandRun",
           "ComponentName": "CarbonUpdate"
-        }
-      ]
-    },
-    {
-      "ComponentName": "GrantGenericWorkerSeAssignPrimaryTokenPrivilege",
-      "ComponentType": "CommandRun",
-      "Comment": "Bug 1303455 - grant SeAssignPrimaryTokenPrivilege, SeIncreaseQuotaPrivilege to g-w user",
-      "Command": "powershell",
-      "Arguments": [
-        "-command",
-        "\"& {&'Import-Module' Carbon}\";",
-        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeAssignPrimaryTokenPrivilege}\""
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "CarbonInstall"
-        },
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "GenericWorkerInstall"
-        }
-      ]
-    },
-    {
-      "ComponentName": "GrantGenericWorkerSeIncreaseQuotaPrivilege",
-      "ComponentType": "CommandRun",
-      "Comment": "Bug 1303455 - grant SeAssignPrimaryTokenPrivilege, SeIncreaseQuotaPrivilege to g-w user",
-      "Command": "powershell",
-      "Arguments": [
-        "-command",
-        "\"& {&'Import-Module' Carbon}\";",
-        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeIncreaseQuotaPrivilege}\""
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "CarbonInstall"
-        },
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "GenericWorkerInstall"
         }
       ]
     }

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -428,7 +428,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.2alpha1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.0.3alpha1/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -498,7 +498,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.0.2alpha1"
+            "Match": "generic-worker 7.0.3alpha1"
           }
         ]
       }
@@ -1113,48 +1113,6 @@
         {
           "ComponentType": "CommandRun",
           "ComponentName": "CarbonUpdate"
-        }
-      ]
-    },
-    {
-      "ComponentName": "GrantGenericWorkerSeAssignPrimaryTokenPrivilege",
-      "ComponentType": "CommandRun",
-      "Comment": "Bug 1303455 - grant SeAssignPrimaryTokenPrivilege, SeIncreaseQuotaPrivilege to g-w user",
-      "Command": "powershell",
-      "Arguments": [
-        "-command",
-        "\"& {&'Import-Module' Carbon}\";",
-        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeAssignPrimaryTokenPrivilege}\""
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "CarbonInstall"
-        },
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "GenericWorkerInstall"
-        }
-      ]
-    },
-    {
-      "ComponentName": "GrantGenericWorkerSeIncreaseQuotaPrivilege",
-      "ComponentType": "CommandRun",
-      "Comment": "Bug 1303455 - grant SeAssignPrimaryTokenPrivilege, SeIncreaseQuotaPrivilege to g-w user",
-      "Command": "powershell",
-      "Arguments": [
-        "-command",
-        "\"& {&'Import-Module' Carbon}\";",
-        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeIncreaseQuotaPrivilege}\""
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "CarbonInstall"
-        },
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "GenericWorkerInstall"
         }
       ]
     }


### PR DESCRIPTION
@grenade 

The new worker has two changes:

1) it takes care of setting required privileges on install, so no need to do this in the userdata now (so removed those parts). I think the other `Carbon` entries are still needed because of bug 1316329 - but if not, those can also be removed.

2) the `runlib` library has been forked, and modified - hopefully this will solve bug 1303455 - but I won't get too excited quite yet.