### PR TITLE
Relocates user TEMP and TMP env vars to Z: drive

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -925,7 +925,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -934,7 +934,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -929,7 +929,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -938,7 +938,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -923,6 +923,24 @@
       "Target": "Machine"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -552,22 +552,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -552,6 +552,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -925,7 +925,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -934,7 +934,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -929,7 +929,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -938,7 +938,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -923,6 +923,24 @@
       "Target": "Machine"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -552,22 +552,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -552,6 +552,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -925,7 +925,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -934,7 +934,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -929,7 +929,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -938,7 +938,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -923,6 +923,24 @@
       "Target": "Machine"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -552,22 +552,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -552,6 +552,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -925,7 +925,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -934,7 +934,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -929,7 +929,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -938,7 +938,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -923,6 +923,24 @@
       "Target": "Machine"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -552,22 +552,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -552,6 +552,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -389,7 +389,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -398,7 +398,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -385,7 +385,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -394,7 +394,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -321,22 +321,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -383,6 +383,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -321,6 +321,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -380,6 +380,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -386,7 +386,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -395,7 +395,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -321,22 +321,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -382,7 +382,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -391,7 +391,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -321,6 +321,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -380,6 +380,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -386,7 +386,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -395,7 +395,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -321,22 +321,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -382,7 +382,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -391,7 +391,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -321,6 +321,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -380,6 +380,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -386,7 +386,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -395,7 +395,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -321,22 +321,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -382,7 +382,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -391,7 +391,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -321,6 +321,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-alpha.json
+++ b/userdata/Manifest/gecko-t-win7-32-alpha.json
@@ -421,7 +421,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -430,7 +430,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win7-32-alpha.json
+++ b/userdata/Manifest/gecko-t-win7-32-alpha.json
@@ -417,7 +417,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -426,7 +426,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win7-32-alpha.json
+++ b/userdata/Manifest/gecko-t-win7-32-alpha.json
@@ -353,22 +353,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-alpha.json
+++ b/userdata/Manifest/gecko-t-win7-32-alpha.json
@@ -353,6 +353,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-alpha.json
+++ b/userdata/Manifest/gecko-t-win7-32-alpha.json
@@ -415,6 +415,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -418,7 +418,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -427,7 +427,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -412,6 +412,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -353,22 +353,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -353,6 +353,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -414,7 +414,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -423,7 +423,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -418,7 +418,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -427,7 +427,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -412,6 +412,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -353,22 +353,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -353,6 +353,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -414,7 +414,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -423,7 +423,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -418,7 +418,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
@@ -427,7 +427,7 @@
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",
-      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+      "ValueData": "Z:\\Users\\%USERNAME%\\AppData\\Roaming\\Temp"
     },
     {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -412,6 +412,24 @@
       "Target": "C:\\mozilla-build\\tooltool.py"
     },
     {
+      "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
+      "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_USERS\\.DEFAULT\\Environment",
+      "ValueName": "TEMP",
+      "ValueType": "ExpandString",
+      "ValueData": "Z:\Users\%USERNAME%\AppData\Roaming\Temp"
+    },
+    {
       "ComponentName": "reg_WindowsErrorReportingLocalDumps",
       "ComponentType": "RegistryKeySet",
       "Comment": "",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -353,22 +353,6 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
-      "ComponentName": "env_TMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
-      "ComponentName": "env_TEMP",
-      "ComponentType": "EnvironmentVariableSet",
-      "Comment": "Putting temp files on Z: drive should speed things up. :)",
-      "Name": "TEMP",
-      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
-      "Target": "Machine"
-    },
-    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -353,6 +353,22 @@
       "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
     },
     {
+      "ComponentName": "env_TMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_TEMP",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Putting temp files on Z: drive should speed things up. :)",
+      "Name": "TEMP",
+      "Value": "Z:\\Users\\%USERNAME%\\AppData\\Local\\Temp",
+      "Target": "Machine"
+    },
+    {
       "ComponentName": "env_MOZILLABUILD",
       "ComponentType": "EnvironmentVariableSet",
       "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -414,7 +414,7 @@
     {
       "ComponentName": "reg_UsersTMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TMP",
       "ValueType": "ExpandString",
@@ -423,7 +423,7 @@
     {
       "ComponentName": "reg_UsersTEMPEnvVarOnZDrive",
       "ComponentType": "RegistryKeySet",
-      "Comment": "",
+      "Comment": "Updates default user profile so that user temp directories go on Z: drive rather than C: drive",
       "Key": "HKEY_USERS\\.DEFAULT\\Environment",
       "ValueName": "TEMP",
       "ValueType": "ExpandString",


### PR DESCRIPTION
@grenade 

Note, this won't necessarily create the TEMP/TMP dir, but it should at least set it globally so we don't need to set it as part of the task.

I think it makes sense at a system level to decide where temporary files should be written, rather than hardcoding something into the worker, since it should be a per-environment based decision, rather than a common setting across all worker types.