### PR TITLE
Bug 1328241 - upgrade generic worker to reduce worker crashes

### DIFF
--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -442,7 +442,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -512,7 +512,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.1"
+            "Match": "generic-worker 7.2.5"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -442,7 +442,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -512,7 +512,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.1"
+            "Match": "generic-worker 7.2.5"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -442,7 +442,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -512,7 +512,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.1"
+            "Match": "generic-worker 7.2.5"
           }
         ]
       }


### PR DESCRIPTION
Thanks @grenade!

I'll keep a watchful eye out once this lands, to make sure all is still ok.