### PR TITLE
Upgraded gecko-1-b-win2012-beta and gecko-t-win10-64-beta to generic-worker v7.2.5

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -966,7 +966,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1036,7 +1036,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.1"
+            "Match": "generic-worker 7.2.5"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -410,7 +410,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -480,7 +480,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.1"
+            "Match": "generic-worker 7.2.5"
           }
         ]
       }


### PR DESCRIPTION
@grenade Since rolling out to win7, we've had no worker crashes, so I'd like to test this on the other worker types too, first on the "beta" variant. If testing goes well, we should be able to roll out globally. We'll probably still have some win2012 crashes, because those don't reboot between tasks (they don't have a custom `run-generic-worker.bat` script - we can evaluate later if it is better to reboot to avoid these blue jobs - or to leave as they are and accept the occasional blue job, but have less overhead per task.

Thanks!