### PR TITLE
Bug 1329617 - upgrade generic worker from 7.2.5 to 7.2.6

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -966,7 +966,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1036,7 +1036,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.5"
+            "Match": "generic-worker 7.2.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -410,7 +410,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -480,7 +480,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.5"
+            "Match": "generic-worker 7.2.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -442,7 +442,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.6/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -512,7 +512,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.5"
+            "Match": "generic-worker 7.2.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -442,7 +442,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.6/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -512,7 +512,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.5"
+            "Match": "generic-worker 7.2.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -442,7 +442,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.5/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v7.2.6/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -512,7 +512,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 7.2.5"
+            "Match": "generic-worker 7.2.6"
           }
         ]
       }


### PR DESCRIPTION
For win7 and all beta worker type variants.

__Please don't merge until CET working hours so I can be around to support in case of fallout.__

Thanks @grenade!