### PR TITLE
Bump livelog to version 1.0.1

### DIFF
--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -454,7 +454,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/livelog/releases/download/v1.0.0/livelog-windows-386.exe",
+      "Source": "https://github.com/taskcluster/livelog/releases/download/v1.0.1/livelog-windows-386.exe",
       "Target": "C:\\generic-worker\\livelog.exe"
     },
     {


### PR DESCRIPTION
Exposing transfer-encoding CORS requests, so logviewer can detect that the log is live.