### PR TITLE
Bug 1351513 - Mass update to Mercurial 4.1.1

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -539,12 +539,12 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://mercurial-scm.org/release/windows/Mercurial-4.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
-        "/LOG=\"C:\\log\\Mercurial-4.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -552,7 +552,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "78a4a60fd7592ee41aa0267a7c2d1e2b5c0f94502845c980e3d144631a964e71cc1e133895923305efdb85bd1dffadc911a4e8574e099260dd18d96e6d872bcb"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -565,12 +565,12 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -578,7 +578,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -565,12 +565,12 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -578,7 +578,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-3-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-3-b-win2012-beta.json
@@ -539,12 +539,12 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -552,7 +552,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -565,12 +565,12 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -578,7 +578,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -274,13 +274,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -288,7 +288,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -274,13 +274,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -288,7 +288,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -274,13 +274,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -288,7 +288,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -274,13 +274,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -288,7 +288,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -274,13 +274,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -288,7 +288,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -274,13 +274,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1-x64.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1-x64.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -288,7 +288,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "sha512": "9f66f616c96173884fbe9648f996f77733abb949bb609d4409f6bb1a3f2533f4c6e6c068f3e984ea12731979732fb3aaad757f3993e0a4f00256eacfc525e914"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-alpha.json
+++ b/userdata/Manifest/gecko-t-win7-32-alpha.json
@@ -306,13 +306,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -320,7 +320,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "sha512": "c32000ea884bc3f2788fd2a47142465cfc3455a7bad6e642af7a2a12e9e74c8277bb15f4d1e4aa7c7104ce4c37c20ad716687647a0ed82f5ead9427ae295b3b5"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -306,13 +306,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -320,7 +320,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "sha512": "c32000ea884bc3f2788fd2a47142465cfc3455a7bad6e642af7a2a12e9e74c8277bb15f4d1e4aa7c7104ce4c37c20ad716687647a0ed82f5ead9427ae295b3b5"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -306,13 +306,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -320,7 +320,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "sha512": "c32000ea884bc3f2788fd2a47142465cfc3455a7bad6e642af7a2a12e9e74c8277bb15f4d1e4aa7c7104ce4c37c20ad716687647a0ed82f5ead9427ae295b3b5"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -500,13 +500,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -514,7 +514,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "sha512": "c32000ea884bc3f2788fd2a47142465cfc3455a7bad6e642af7a2a12e9e74c8277bb15f4d1e4aa7c7104ce4c37c20ad716687647a0ed82f5ead9427ae295b3b5"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -306,13 +306,13 @@
       "ComponentName": "Mercurial",
       "ComponentType": "ExeInstall",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.1.1.exe",
       "Arguments": [
         "/SP-",
         "/VERYSILENT",
         "/NORESTART",
         "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
+        "/LOG=\"C:\\log\\Mercurial-4.1.1.exe.install.log\""
       ],
       "Validate": {
         "PathsExist": [
@@ -320,7 +320,7 @@
           "C:\\Program Files\\Mercurial\\python27.dll"
         ]
       },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "sha512": "c32000ea884bc3f2788fd2a47142465cfc3455a7bad6e642af7a2a12e9e74c8277bb15f4d1e4aa7c7104ce4c37c20ad716687647a0ed82f5ead9427ae295b3b5"
     },
     {
       "ComponentName": "MercurialConfig",


### PR DESCRIPTION
I'm trying to get Mercurial 4.1 deployed everywhere at Mozilla.

This is a precursor to me installing a hacked up version of 4.1 to test fixes for the "stream ended unexpectedly" failures that keep popping up in automation. But that's for another pull request. The important thing is we get 4.1 verified to be working.