### PR TITLE
Upgrade generic worker to 8.1.0 in *beta* worker types

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1008,7 +1008,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1078,7 +1078,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.1.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-3-b-win2012-beta.json
@@ -1008,7 +1008,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1078,7 +1078,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.1.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.1.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -520,7 +520,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.1.0"
           }
         ]
       }


### PR DESCRIPTION
@grenade This adds support for specifying an artifact name which is different to the artifact path (i.e. so you can name your artifacts independently from where they are on the filesystem).

Note, it is backwardly compatible, so if you don't specify an artifact name, the artifact path is used for the name, as before.