### PR TITLE
Upgrade generic-worker to version 8.2.0 in beta worker types

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -307,7 +307,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -377,7 +377,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-3-b-win2012-beta.json
@@ -1008,7 +1008,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1078,7 +1078,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.0"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -520,7 +520,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }


### PR DESCRIPTION
@grenade 

This picks up the fixes in generic worker from bugs [1338464](https://bugzilla.mozilla.org/show_bug.cgi?id=1338464) and [1356800](https://bugzilla.mozilla.org/show_bug.cgi?id=1356800) and applies them to the __beta__ worker types only.

__Note__, release 8.2.0 is currently in progress, but __when the win32 and win64__ binaries appear [here](https://github.com/taskcluster/generic-worker/releases/tag/v8.2.0) this PR should be safe to merge.

CC @garndt