### PR TITLE
Bug 1343582, Bug 1347956 - upgrade generic-worker to 8.3.0 on beta worker types

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1034,7 +1034,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1104,7 +1104,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-3-b-win2012-beta.json
@@ -1008,7 +1008,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1078,7 +1078,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -520,7 +520,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }


### PR DESCRIPTION
@grenade A new day, a new release!

The [try push of 8.2.0](https://treeherder.mozilla.org/#/jobs?repo=try&revision=4c74a5a145740c8393f9f797c4c593ce4818b935) was successful. This builds on top of that with fixes for bug 1343582 and bug 1347956. Again, just for the __beta__ worker types.

These fixes hopefully solve the "black screen" issue we've been having on Windows 10, and also should use gzip content encoding on more artifacts, which should considerably reduce storage requirements.

CC @gregarndt @edmorley