### PR TITLE
Upgrade all generic-worker installations to at least version 8.2.0

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-gdt.json
+++ b/userdata/Manifest/gecko-1-b-win2012-gdt.json
@@ -300,7 +300,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -370,7 +370,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1034,7 +1034,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1104,7 +1104,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-1-b-win2016.json
+++ b/userdata/Manifest/gecko-1-b-win2016.json
@@ -294,7 +294,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -364,7 +364,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1034,7 +1034,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1104,7 +1104,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1034,7 +1034,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.0.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1104,7 +1104,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.0.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -641,7 +641,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -719,7 +719,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -520,7 +520,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -722,7 +722,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -800,7 +800,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.1.1/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -520,7 +520,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.1.1"
+            "Match": "generic-worker 8.2.0"
           }
         ]
       }


### PR DESCRIPTION
@grenade As there is a delay to 8.3.0 rollout, let's go with 8.2.0 for now, which is already tested on the betas.