### PR TITLE
Created worker type gecko-t-win10-64-gpu-b(eta)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -732,6 +732,60 @@ tasks:
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
+          - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-gpu-b
+          - secrets:set:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-gpu-b
+          - aws-provisioner:manage-worker-type:gecko-t-win10-64-gpu-b
+      routes:
+          - 'index.project.releng.opencloudconfig.v1.revision.{{event.head.sha}}.gecko-t-win10-64-gpu-b'
+      workerType: '{{taskcluster.docker.workerType}}'
+      extra:
+          github:
+              env: true
+              events:
+                  - push
+              branches:
+                - master
+          data:
+              head:
+                  sha: '{{event.head.sha}}'
+                  user:
+                      email: '{{event.head.user.email}}'
+      payload:
+          maxRunTime: 10800
+          image: 'grenade/opencloudconfig'
+          features:
+              taskclusterProxy: true
+          command:
+              - '/bin/bash'
+              - '--login'
+              - '-c'
+              - 'git clone --quiet {{event.head.repo.url}} && ./OpenCloudConfig/ci/update-workertype.sh gecko-t-win10-64-gpu-b'
+          artifacts:
+              'project/releng/opencloudconfig/update-request.json':
+                  type: file
+                  path: './gecko-t-win10-64-gpu-b.json'
+                  expires: "{{ '4 hours' | $fromNow }}"
+              'project/releng/opencloudconfig/update-response.json':
+                  type: file
+                  path: './update-response.json'
+                  expires: "{{ '4 hours' | $fromNow }}"
+              'project/releng/opencloudconfig/secret-update-response.json':
+                  type: file
+                  path: './secret-update-response.json'
+                  expires: "{{ '4 hours' | $fromNow }}"
+              'project/releng/opencloudconfig/gecko-t-win10-64-gpu-b.diff':
+                  type: file
+                  path: './gecko-t-win10-64-gpu-b.diff'
+                  expires: "{{ '1 year' | $fromNow }}"
+      metadata:
+          name: 'Update gecko-t-win10-64-gpu-b AMIs'
+          description: 'recreate Experimental Firefox Windows 10 (64 bit) GPU test AMIs using OpenCloudConfig for configuration and dependency installation'
+          owner: '{{event.head.user.email}}'
+          source: '{{event.head.repo.url}}'
+
+    - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      scopes:
+          - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-gpu
           - secrets:set:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-gpu
           - aws-provisioner:manage-worker-type:gecko-t-win10-64-gpu
@@ -779,7 +833,7 @@ tasks:
                   expires: "{{ '1 year' | $fromNow }}"
       metadata:
           name: 'Update gecko-t-win10-64-gpu AMIs'
-          description: 'recreate Firefox Windows 10 (64 bit) test AMIs using OpenCloudConfig for configuration and dependency installation'
+          description: 'recreate Firefox Windows 10 (64 bit) GPU test AMIs using OpenCloudConfig for configuration and dependency installation'
           owner: '{{event.head.user.email}}'
           source: '{{event.head.repo.url}}'
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Which manifest to run is currently determined by the ssh key associated with the
   - Experimental:
     - [gecko-t-win7-32-beta](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win7-32-beta.json) Windows 7 - 32 bit
     - [gecko-t-win10-64-beta](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win10-64-beta.json) Windows 10 - 64 bit
-    - [gecko-t-win10-64-gpu-b](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win10-64-gpu-b.json) Windows 10 - 64 bit
+    - [gecko-t-win10-64-gpu-b](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win10-64-gpu-b.json) Windows 10 - 64 bit with GPU
 
 Running the following command at an elevated powershell prompt (or providing it as EC2 userdata) will start OCC on an instance:
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Which manifest to run is currently determined by the ssh key associated with the
   - Experimental:
     - [gecko-t-win7-32-beta](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win7-32-beta.json) Windows 7 - 32 bit
     - [gecko-t-win10-64-beta](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win10-64-beta.json) Windows 10 - 64 bit
+    - [gecko-t-win10-64-gpu-b](https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Manifest/gecko-t-win10-64-gpu-b.json) Windows 10 - 64 bit
 
 Running the following command at an elevated powershell prompt (or providing it as EC2 userdata) will start OCC on an instance:
 

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1,0 +1,1091 @@
+{
+  "Components": [
+    {
+      "ComponentName": "LogDirectory",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "Required by OpenCloudConfig for DSC logging",
+      "Path": "C:\\log"
+    },
+    {
+      "ComponentName": "NxLog",
+      "ComponentType": "MsiInstall",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Url": "http://nxlog.co/system/files/products/files/1/nxlog-ce-2.9.1716.msi",
+      "Name": "NxLog-CE",
+      "ProductId": "FC526514-AFD9-4A5C-8677-56241539609D",
+      "sha512": "70f5516bca0ff7814833ef397c01dbcd1c7011c0ef4b0f2aeda2e1aa7c02fe680eddfd1c0656f8d438559e34e5a841360dc6dafa7843c610528df2e1defb02be"
+    },
+    {
+      "ComponentName": "PaperTrailEncryptionCertificate",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Source": "https://papertrailapp.com/tools/papertrail-bundle.pem",
+      "Target": "C:\\Program Files (x86)\\nxlog\\cert\\papertrail-bundle.pem",
+      "DependsOn": [
+        {
+          "ComponentType": "MsiInstall",
+          "ComponentName": "NxLog"
+        }
+      ]
+    },
+    {
+      "ComponentName": "NxLogPaperTrailConfiguration",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/nxlog/win10.conf",
+      "Target": "C:\\Program Files (x86)\\nxlog\\conf\\nxlog.conf",
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "PaperTrailEncryptionCertificate"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Start_nxlog",
+      "ComponentType": "ServiceControl",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Name": "nxlog",
+      "StartupType": "Automatic",
+      "State": "Running",
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "NxLogPaperTrailConfiguration"
+        }
+      ]
+    },
+    {
+      "ComponentName": "ProcessExplorer",
+      "ComponentType": "ZipInstall",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Url": "https://download.sysinternals.com/files/ProcessExplorer.zip",
+      "Destination": "C:\\ProcessExplorer",
+      "sha512": "ef89598b2d7f4659a98b0ace28f5b5274a93203d2a2296e37eadedf8cb0337ee5ccc161377644dae1c3e8526fc2545190077635e07458f7e4e74c5b3241f5e30"
+    },
+    {
+      "ComponentName": "ProcessMonitor",
+      "ComponentType": "ZipInstall",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Url": "https://download.sysinternals.com/files/ProcessMonitor.zip",
+      "Destination": "C:\\ProcessMonitor",
+      "sha512": "0269c0354eb21345abe28da97043c88da2de2f27f84030c6746b7019368b482027a6a9ef48d715e11e389c7e12a89b8d638408f8826cebf72b886ec24ea776a1"
+    },
+    {
+      "ComponentName": "GpgForWin",
+      "ComponentType": "ExeInstall",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Url": "http://files.gpg4win.org/gpg4win-2.3.0.exe",
+      "Arguments": [
+        "/S"
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Program Files (x86)\\GNU\\GnuPG\\pub\\gpg.exe",
+          "C:\\Program Files (x86)\\GNU\\GnuPG\\pub\\gpg2.exe"
+        ]
+      },
+      "sha512": "b1c48d84d041055db3d3e3cbd22ef2f3300728b06c76660b9b78ececf56b7ccbc80addb39a64c0a4eb68bf3463ceb6d254dedda047049ce680e9d543dd8a9af9"
+    },
+    {
+      "ComponentName": "SevenZip",
+      "ComponentType": "ExeInstall",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Url": "http://7-zip.org/a/7z1514-x64.exe",
+      "Arguments": [
+        "/S"
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Program Files\\7-Zip\\7z.exe",
+          "C:\\Program Files\\7-Zip\\7z.dll"
+        ]
+      },
+      "sha512": "4df02ab139b087c8d6e689a99afb58e1ab3d4c0722daa11f6a070cddb2506d079a7d9ff55341baa5b7fd1dc7593225eb9d7fdbfb9ac91e0d8db61f9fda85cbb3"
+    },
+    {
+      "ComponentName": "SublimeText3",
+      "ComponentType": "ExeInstall",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Url": "https://download.sublimetext.com/Sublime%20Text%20Build%203114%20x64%20Setup.exe",
+      "Arguments": [
+        "/VERYSILENT",
+        "/NORESTART",
+        "/TASKS=\"contextentry\""
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Program Files\\Sublime Text 3\\subl.exe",
+          "C:\\Program Files\\Sublime Text 3\\sublime_text.exe"
+        ]
+      },
+      "sha512": "d3e71b28567ddd1b486aa3dcc9814818d91c322bc20ec203018d74bc465835f9ddd34d78f674172d00e66b39443070eb45e9799e3801b0ac410c958b2cf21098"
+    },
+    {
+      "ComponentName": "SublimeText3_PackagesFolder",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Path": "C:\\Users\\Administrator\\AppData\\Roaming\\Sublime Text 3\\Packages"
+    },
+    {
+      "ComponentName": "SublimeText3_PackageControl",
+      "ComponentType": "FileDownload",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Source": "http://sublime.wbond.net/Package%20Control.sublime-package",
+      "Target": "C:\\Users\\Administrator\\AppData\\Roaming\\Sublime Text 3\\Packages\\Package Control.sublime-package",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "SublimeText3"
+        },
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "SublimeText3_PackagesFolder"
+        }
+      ]
+    },
+    {
+      "ComponentName": "SystemPowerShellProfile",
+      "ComponentType": "FileDownload",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/Microsoft.PowerShell_profile.ps1",
+      "Target": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Microsoft.PowerShell_profile.ps1"
+    },
+    {
+      "ComponentName": "FsutilDisable8Dot3",
+      "ComponentType": "CommandRun",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Command": "fsutil.exe",
+      "Arguments": [
+        "behavior",
+        "set",
+        "disable8dot3",
+        "1"
+      ],
+      "Validate": {
+        "CommandsReturn": [
+          {
+            "Command": "fsutil.exe",
+            "Arguments": [
+              "behavior",
+              "query",
+              "disable8dot3"
+            ],
+            "Match": "The registry state is: 1 (Disable 8dot3 name creation on all volumes)."
+          }
+        ]
+      }
+    },
+    {
+      "ComponentName": "FsutilDisableLastAccess",
+      "ComponentType": "CommandRun",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Command": "fsutil.exe",
+      "Arguments": [
+        "behavior",
+        "set",
+        "disablelastaccess",
+        "1"
+      ],
+      "Validate": {
+        "CommandsReturn": [
+          {
+            "Command": "fsutil.exe",
+            "Arguments": [
+              "behavior",
+              "query",
+              "disablelastaccess"
+            ],
+            "Match": "DisableLastAccess = 1"
+          }
+        ]
+      }
+    },
+    {
+      "ComponentName": "home",
+      "ComponentType": "SymbolicLink",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Target": "C:\\Users",
+      "Link": "C:\\home"
+    },
+    {
+      "ComponentName": "MozillaBuildSetup",
+      "ComponentType": "ExeInstall",
+      "Comment": "Base Firefox on Windows build requirement",
+      "Arguments": [
+        "/S",
+        "/D=C:\\mozilla-build"
+      ],
+      "Url": "http://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-2.2.0.exe",
+      "Validate": {
+        "PathsExist": [
+          "C:\\mozilla-build\\info-zip\\unzip.exe",
+          "C:\\mozilla-build\\info-zip\\zip.exe",
+          "C:\\mozilla-build\\msys\\bin\\sh.exe",
+          "C:\\mozilla-build\\msys\\local\\bin\\make.exe",
+          "C:\\mozilla-build\\msys\\local\\bin\\autoconf-2.13",
+          "C:\\mozilla-build\\python\\python.exe",
+          "C:\\mozilla-build\\upx391w\\upx.exe",
+          "C:\\mozilla-build\\yasm\\yasm.exe"
+        ],
+        "FilesContain": [
+          {
+            "Path": "C:\\mozilla-build\\VERSION",
+            "Match": "2.2.0"
+          }
+        ]
+      },
+      "sha512": "b593aa4ed9ff34bd4a20860fec478b3638ff1f916a60dc79ebcff46cee279fdb59dd53a36579378f0e11f4be201114578a429bfbfc11eda195a0b1db7aa9831e"
+    },
+    {
+      "ComponentName": "msys_home",
+      "ComponentType": "SymbolicLink",
+      "Comment": "Maintenance Toolchain - not essential for building firefox",
+      "Target": "C:\\Users",
+      "Link": "C:\\mozilla-build\\msys\\home",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        }
+      ]
+    },
+    {
+      "ComponentName": "DeleteMozillaBuildMercurial",
+      "ComponentType": "CommandRun",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        }
+      ],
+      "Command": "del",
+      "Arguments": [
+        "C:\\mozilla-build\\python\\Scripts\\hg*"
+      ],
+      "Validate": {
+        "PathsNotExist": [
+          "C:\\mozilla-build\\python\\hg",
+          "C:\\mozilla-build\\python\\hg.exe"
+        ]
+      }
+    },
+    {
+      "ComponentName": "Mercurial",
+      "ComponentType": "ExeInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
+      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
+      "Arguments": [
+        "/SP-",
+        "/VERYSILENT",
+        "/NORESTART",
+        "/DIR=expand:{pf}\\Mercurial",
+        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Program Files\\Mercurial\\hg.exe",
+          "C:\\Program Files\\Mercurial\\python27.dll"
+        ]
+      },
+      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+    },
+    {
+      "ComponentName": "MercurialConfig",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "Required by clonebundle and share hg extensions",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "Mercurial"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/Mercurial/mercurial.ini",
+      "Target": "C:\\Program Files\\Mercurial\\Mercurial.ini"
+    },
+    {
+      "ComponentName": "robustcheckout",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "Required by robustcheckout hg extension",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/FirefoxBuildResources/robustcheckout.py",
+      "Target": "C:\\mozilla-build\\robustcheckout.py"
+    },
+    {
+      "ComponentName": "MercurialCerts",
+      "ComponentType": "ChecksumFileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "Mercurial"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/Mercurial/cacert.pem",
+      "Target": "C:\\mozilla-build\\msys\\etc\\cacert.pem"
+    },
+    {
+      "ComponentName": "env_MOZILLABUILD",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "Absolutely required for mozharness builds. Python will fall in a heap, throwing misleading exceptions without this. :)",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        }
+      ],
+      "Name": "MOZILLABUILD",
+      "Value": "C:\\mozilla-build",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "env_PATH",
+      "ComponentType": "EnvironmentVariableUniquePrepend",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        },
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "Mercurial"
+        }
+      ],
+      "Name": "PATH",
+      "Values": [
+        "C:\\Program Files\\Mercurial",
+        "C:\\mozilla-build\\7zip",
+        "C:\\mozilla-build\\info-zip",
+        "C:\\mozilla-build\\kdiff3",
+        "C:\\mozilla-build\\moztools-x64\\bin",
+        "C:\\mozilla-build\\mozmake",
+        "C:\\mozilla-build\\msys\\bin",
+        "C:\\mozilla-build\\msys\\local\\bin",
+        "C:\\mozilla-build\\nsis-3.0b3",
+        "C:\\mozilla-build\\nsis-2.46u",
+        "C:\\mozilla-build\\python",
+        "C:\\mozilla-build\\python\\Scripts",
+        "C:\\mozilla-build\\upx391w",
+        "C:\\mozilla-build\\wget",
+        "C:\\mozilla-build\\yasm"
+      ],
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "ToolToolInstall",
+      "ComponentType": "FileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla/build-tooltool/master/tooltool.py",
+      "Target": "C:\\mozilla-build\\tooltool.py"
+    },
+    {
+      "ComponentName": "reg_WindowsErrorReportingLocalDumps",
+      "ComponentType": "RegistryKeySet",
+      "Comment": "",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting",
+      "ValueName": "LocalDumps"
+    },
+    {
+      "ComponentName": "reg_WindowsErrorReportingDontShowUI",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting",
+      "ValueName": "DontShowUI",
+      "ValueType": "Dword",
+      "ValueData": "0x00000001",
+      "Hex": true
+    },
+    {
+      "ComponentName": "GenericWorkerDirectory",
+      "ComponentType": "DirectoryCreate",
+      "Path": "C:\\generic-worker"
+    },
+    {
+      "ComponentName": "GenericWorkerDownload",
+      "ComponentType": "ChecksumFileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "GenericWorkerDirectory"
+        }
+      ],
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
+      "Target": "C:\\generic-worker\\generic-worker.exe"
+    },
+    {
+      "ComponentName": "LiveLogDownload",
+      "ComponentType": "FileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "GenericWorkerDirectory"
+        }
+      ],
+      "Source": "https://github.com/taskcluster/livelog/releases/download/v1.1.0/livelog-windows-amd64.exe",
+      "Target": "C:\\generic-worker\\livelog.exe"
+    },
+    {
+      "ComponentName": "LiveLog_Get",
+      "ComponentType": "FirewallRule",
+      "Protocol": "TCP",
+      "LocalPort": 60022,
+      "Direction": "Inbound",
+      "Action": "Allow"
+    },
+    {
+      "ComponentName": "LiveLog_Put",
+      "ComponentType": "FirewallRule",
+      "Protocol": "TCP",
+      "LocalPort": 60023,
+      "Direction": "Inbound",
+      "Action": "Allow"
+    },
+    {
+      "ComponentName": "GenericWorkerInstall",
+      "ComponentType": "CommandRun",
+      "Command": "C:\\generic-worker\\generic-worker.exe",
+      "Arguments": [
+        "install",
+        "startup",
+        "--config",
+        "C:\\generic-worker\\generic-worker.config"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "GenericWorkerDownload"
+        },
+        {
+          "ComponentType": "FileDownload",
+          "ComponentName": "LiveLogDownload"
+        },
+        {
+          "ComponentType": "FirewallRule",
+          "ComponentName": "LiveLog_Get"
+        },
+        {
+          "ComponentType": "FirewallRule",
+          "ComponentName": "LiveLog_Put"
+        }
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\generic-worker\\run-generic-worker.bat",
+          "C:\\generic-worker\\generic-worker.exe"
+        ],
+        "CommandsReturn": [
+          {
+            "Command": "C:\\generic-worker\\generic-worker.exe",
+            "Arguments": [
+              "--version"
+            ],
+            "Match": "generic-worker 8.3.0"
+          }
+        ]
+      }
+    },
+    {
+      "ComponentName": "DisableDesktopInterrupt",
+      "ComponentType": "ChecksumFileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/disable-desktop-interrupt.reg",
+      "Target": "C:\\generic-worker\\disable-desktop-interrupt.reg"
+    },
+    {
+      "ComponentName": "GenericWorkerStateWait",
+      "ComponentType": "ChecksumFileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        },
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "DisableDesktopInterrupt"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker.bat",
+      "Target": "C:\\generic-worker\\run-generic-worker.bat"
+    },
+    {
+      "ComponentName": "TaskUserInitScript",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "Bug 1261188 - initialisation script for new task users",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/task-user-init-win10.cmd",
+      "Target": "C:\\generic-worker\\task-user-init.cmd",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "GenericWorkerDirectory"
+        }
+      ]
+    },
+    {
+      "ComponentName": "PipConfDirectory",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "https://pip.pypa.io/en/stable/user_guide/#config-file",
+      "Path": "C:\\ProgramData\\pip"
+    },
+    {
+      "ComponentName": "PipConf",
+      "ComponentType": "ChecksumFileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "PipConfDirectory"
+        }
+      ],
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/pip.conf",
+      "Target": "C:\\ProgramData\\pip\\pip.ini"
+    },
+    {
+      "ComponentName": "virtualenv_support",
+      "ComponentType": "DirectoryCreate",
+      "Path": "C:\\mozilla-build\\python\\Lib\\site-packages\\virtualenv_support",
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "MozillaBuildSetup"
+        }
+      ]
+    },
+    {
+      "ComponentName": "virtualenv_support_pywin32",
+      "ComponentType": "FileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "virtualenv_support"
+        }
+      ],
+      "Source": "https://pypi.python.org/packages/cp27/p/pypiwin32/pypiwin32-219-cp27-none-win32.whl#md5=a8b0c1b608c1afeb18cd38d759ee5e29",
+      "Target": "C:\\mozilla-build\\python\\Lib\\site-packages\\virtualenv_support\\pypiwin32-219-cp27-none-win32.whl"
+    },
+    {
+      "ComponentName": "virtualenv_support_pywin32_amd64",
+      "ComponentType": "FileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "virtualenv_support"
+        }
+      ],
+      "Source": "https://pypi.python.org/packages/cp27/p/pypiwin32/pypiwin32-219-cp27-none-win_amd64.whl#md5=d7bafcf3cce72c3ce9fdd633a262c335",
+      "Target": "C:\\mozilla-build\\python\\Lib\\site-packages\\virtualenv_support\\pypiwin32-219-cp27-none-win_amd64.whl"
+    },
+    {
+      "ComponentName": "HgShared",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "allows builds to use `hg robustcheckout ...`",
+      "Path": "y:\\hg-shared"
+    },
+    {
+      "ComponentName": "HgSharedAccessRights",
+      "ComponentType": "CommandRun",
+      "Comment": "allows builds to use `hg robustcheckout ...`",
+      "Command": "icacls.exe",
+      "Arguments": [
+        "y:\\hg-shared",
+        "/grant",
+        "Everyone:(OI)(CI)F"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "HgShared"
+        }
+      ]
+    },
+    {
+      "ComponentName": "PipCache",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "share pip cache across subsequent task users",
+      "Path": "y:\\pip-cache"
+    },
+    {
+      "ComponentName": "PipCacheAccessRights",
+      "ComponentType": "CommandRun",
+      "Comment": "share pip cache across subsequent task users",
+      "Command": "icacls.exe",
+      "Arguments": [
+        "y:\\pip-cache",
+        "/grant",
+        "Everyone:(OI)(CI)F"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "PipCache"
+        }
+      ]
+    },
+    {
+      "ComponentName": "env_PIP_DOWNLOAD_CACHE",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "share pip download cache between tasks",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "PipCacheAccessRights"
+        }
+      ],
+      "Name": "PIP_DOWNLOAD_CACHE",
+      "Value": "y:\\pip-cache",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "TooltoolCache",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "share tooltool cache across subsequent task users",
+      "Path": "y:\\tooltool-cache"
+    },
+    {
+      "ComponentName": "TooltoolCacheAccessRights",
+      "ComponentType": "CommandRun",
+      "Comment": "share tooltool cache across subsequent task users",
+      "Command": "icacls.exe",
+      "Arguments": [
+        "y:\\tooltool-cache",
+        "/grant",
+        "Everyone:(OI)(CI)F"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "TooltoolCache"
+        }
+      ]
+    },
+    {
+      "ComponentName": "env_TOOLTOOL_CACHE",
+      "ComponentType": "EnvironmentVariableSet",
+      "Comment": "share tooltool cache between tasks",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "TooltoolCacheAccessRights"
+        }
+      ],
+      "Name": "TOOLTOOL_CACHE",
+      "Value": "y:\\tooltool-cache",
+      "Target": "Machine"
+    },
+    {
+      "ComponentName": "CarbonClone",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1316329 - support creation of symlinks by task users",
+      "Command": "C:\\Program Files\\Mercurial\\hg.exe",
+      "Arguments": [
+        "clone",
+        "--insecure",
+        "https://bitbucket.org/splatteredbits/carbon",
+        "C:\\Windows\\Temp\\carbon"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "Mercurial"
+        }
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Windows\\Temp\\carbon\\.hg"
+        ]
+      }
+    },
+    {
+      "ComponentName": "CarbonUpdate",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1316329 - support creation of symlinks by task users",
+      "Command": "C:\\Program Files\\Mercurial\\hg.exe",
+      "Arguments": [
+        "update",
+        "2.4.0",
+        "-R",
+        "C:\\Windows\\Temp\\carbon"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonClone"
+        }
+      ]
+    },
+    {
+      "ComponentName": "CarbonInstall",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1316329 - support creation of symlinks by task users",
+      "Command": "xcopy",
+      "Arguments": [
+        "C:\\Windows\\Temp\\carbon\\Carbon",
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules\\Carbon",
+        "/e",
+        "/i",
+        "/y"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonUpdate"
+        }
+      ]
+    },
+    {
+      "ComponentName": "GrantEveryoneSeCreateSymbolicLinkPrivilege",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1316329 - support creation of symlinks by task users",
+      "Command": "powershell",
+      "Arguments": [
+        "-command",
+        "\"& {&'Import-Module' Carbon}\";",
+        "\"& {&'Grant-Privilege' -Identity Everyone -Privilege SeCreateSymbolicLinkPrivilege}\""
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonInstall"
+        }
+      ]
+    },
+    {
+      "ComponentName": "GrantGenericWorkerSeAssignPrimaryTokenPrivilege",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1303455 - grant SeAssignPrimaryTokenPrivilege to g-w user",
+      "Command": "powershell",
+      "Arguments": [
+        "-command",
+        "\"& {&'Import-Module' Carbon}\";",
+        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeAssignPrimaryTokenPrivilege}\""
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonInstall"
+        },
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        }
+      ]
+    },
+    {
+      "ComponentName": "GrantGenericWorkerSeIncreaseQuotaPrivilege",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1303455 - grant SeIncreaseQuotaPrivilege to g-w user",
+      "Command": "powershell",
+      "Arguments": [
+        "-command",
+        "\"& {&'Import-Module' Carbon}\";",
+        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeIncreaseQuotaPrivilege}\""
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonInstall"
+        },
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        }
+      ]
+    },
+    {
+      "ComponentName": "GrantGenericWorkerSeIncreaseBasePriorityPrivilege",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1312383 - grant SeIncreaseBasePriorityPrivilege to g-w user",
+      "Command": "powershell",
+      "Arguments": [
+        "-command",
+        "\"& {&'Import-Module' Carbon}\";",
+        "\"& {&'Grant-Privilege' -Identity GenericWorker -Privilege SeIncreaseBasePriorityPrivilege}\""
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonInstall"
+        },
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        }
+      ]
+    },
+    {
+      "ComponentName": "reg_PythonCpuPriority",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\python.exe\\PerfOptions",
+      "ValueName": "CpuPriorityClass",
+      "ValueType": "Dword",
+      "ValueData": "0x00000006",
+      "Hex": true
+    },
+    {
+      "ComponentName": "reg_PythonIoPriority",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\python.exe\\PerfOptions",
+      "ValueName": "IoPriority",
+      "ValueType": "Dword",
+      "ValueData": "0x00000002",
+      "Hex": true
+    },
+    {
+      "ComponentName": "reg_MercurialCpuPriority",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\hg.exe\\PerfOptions",
+      "ValueName": "CpuPriorityClass",
+      "ValueType": "Dword",
+      "ValueData": "0x00000006",
+      "Hex": true
+    },
+    {
+      "ComponentName": "reg_MercurialIoPriority",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\hg.exe\\PerfOptions",
+      "ValueName": "IoPriority",
+      "ValueType": "Dword",
+      "ValueData": "0x00000002",
+      "Hex": true
+    },
+    {
+      "ComponentName": "MozillaMaintenanceDir",
+      "ComponentType": "DirectoryCreate",
+      "Comment": "Working directory for Mozilla Maintenance Service installation",
+      "Path": "C:\\dsc\\MozillaMaintenance"
+    },
+    {
+      "ComponentName": "maintenanceservice_installer",
+      "ComponentType": "ChecksumFileDownload",
+      "Source": "https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Configuration/Mozilla%20Maintenance%20Service/maintenanceservice_installer.exe?raw=true",
+      "Target": "C:\\dsc\\MozillaMaintenance\\maintenanceservice_installer.exe",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "MozillaMaintenanceDir"
+        }
+      ]
+    },
+    {
+      "ComponentName": "maintenanceservice",
+      "ComponentType": "ChecksumFileDownload",
+      "Source": "https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Configuration/Mozilla%20Maintenance%20Service/maintenanceservice.exe?raw=true",
+      "Target": "C:\\dsc\\MozillaMaintenance\\maintenanceservice.exe",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "MozillaMaintenanceDir"
+        }
+      ]
+    },
+    {
+      "ComponentName": "maintenanceservice_install",
+      "ComponentType": "CommandRun",
+      "Command": "C:\\dsc\\MozillaMaintenance\\maintenanceservice_installer.exe",
+      "Arguments": [
+        "/s"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "maintenanceservice_installer"
+        },
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "maintenanceservice"
+        }
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Program Files (x86)\\Mozilla Maintenance Service\\maintenanceservice.exe",
+          "C:\\Program Files (x86)\\Mozilla Maintenance Service\\Uninstall.exe"
+        ]
+      }
+    },
+    {
+      "ComponentName": "MozFakeCA.cer",
+      "ComponentType": "ChecksumFileDownload",
+      "Source": "https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Configuration/Mozilla%20Maintenance%20Service/MozFakeCA.cer?raw=true",
+      "Target": "C:\\dsc\\MozillaMaintenance\\MozFakeCA.cer",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "MozillaMaintenanceDir"
+        }
+      ]
+    },
+    {
+      "ComponentName": "MozFakeCA.cer",
+      "ComponentType": "CommandRun",
+      "Command": "certutil.exe",
+      "Arguments": [
+        "-addstore",
+        "Root",
+        "C:\\dsc\\MozillaMaintenance\\MozFakeCA.cer"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "MozFakeCA.cer"
+        }
+      ]
+    },
+    {
+      "ComponentName": "MozRoot.cer",
+      "ComponentType": "ChecksumFileDownload",
+      "Source": "https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Configuration/Mozilla%20Maintenance%20Service/MozRoot.cer?raw=true",
+      "Target": "C:\\dsc\\MozillaMaintenance\\MozRoot.cer",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "MozillaMaintenanceDir"
+        }
+      ]
+    },
+    {
+      "ComponentName": "MozRoot.cer",
+      "ComponentType": "CommandRun",
+      "Command": "certutil.exe",
+      "Arguments": [
+        "-addstore",
+        "Root",
+        "C:\\dsc\\MozillaMaintenance\\MozRoot.cer"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "MozRoot.cer"
+        }
+      ]
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_0_name",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\0",
+      "ValueName": "name",
+      "ValueType": "String",
+      "ValueData": "Mozilla Corporation"
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_0_issuer",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\0",
+      "ValueName": "issuer",
+      "ValueType": "String",
+      "ValueData": "Thawte Code Signing CA - G2"
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_0_programName",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\0",
+      "ValueName": "programName",
+      "ValueType": "String",
+      "ValueData": ""
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_0_publisherLink",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\0",
+      "ValueName": "publisherLink",
+      "ValueType": "String",
+      "ValueData": ""
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_1_name",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\1",
+      "ValueName": "name",
+      "ValueType": "String",
+      "ValueData": "Mozilla Fake SPC"
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_1_issuer",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\1",
+      "ValueName": "issuer",
+      "ValueType": "String",
+      "ValueData": "Mozilla Fake CA"
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_1_programName",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\1",
+      "ValueName": "programName",
+      "ValueType": "String",
+      "ValueData": ""
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_1_publisherLink",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\1",
+      "ValueName": "publisherLink",
+      "ValueType": "String",
+      "ValueData": ""
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_2_name",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\2",
+      "ValueName": "name",
+      "ValueType": "String",
+      "ValueData": "Mozilla Corporation"
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_2_issuer",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\2",
+      "ValueName": "issuer",
+      "ValueType": "String",
+      "ValueData": "DigiCert SHA2 Assured ID Code Signing CA"
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_2_programName",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\2",
+      "ValueName": "programName",
+      "ValueType": "String",
+      "ValueData": ""
+    },
+    {
+      "ComponentName": "reg_Mozilla_MaintenanceService_3932ecacee736d366d6436db0f55bce4_2_publisherLink",
+      "ComponentType": "RegistryValueSet",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Mozilla\\MaintenanceService\\3932ecacee736d366d6436db0f55bce4\\2",
+      "ValueName": "publisherLink",
+      "ValueType": "String",
+      "ValueData": ""
+    },
+    {
+      "ComponentName": "GrantGenericWorkerMozillaRegistryWriteAccess",
+      "ComponentType": "CommandRun",
+      "Comment": "Bug 1353889 - Grant GenericWorker account write access to Mozilla registry key",
+      "Command": "powershell",
+      "Arguments": [
+        "-command",
+        "\"& {& (Get-Acl -Path 'HKLM:\\SOFTWARE\\Mozilla').SetAccessRule(New-Object System.Security.AccessControl.RegistryAccessRule ('.\\GenericWorker', 'FullControl', 'Allow'))}\";",
+        "\"& {& ((Get-Acl -Path 'HKLM:\\SOFTWARE\\Mozilla') | Set-Acl -Path 'HKLM:\\SOFTWARE\\Mozilla')}\""
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "CarbonInstall"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The name `gecko-t-win10-64-gpu-beta` is too long so I was forced to shorten it to `gecko-t-win10-64-gpu-b`.

This is useful so screenshots will also work on gpu instances - at the moment we can't roll out 8.3.0 globally since older versions of mozharness don't respect `Content-Encoding` header of artifacts that the new 8.3.0 version of generic-worker produces. This has been fixed on mozilla-inbound / mozilla-central but it might take a while for try users to update their base revision, and I'm not sure if we have jobs running on other trees that might not have picked up this mozharness fix yet - so in order to unblock win10 testers, they can use this worker type, so long as they have an up-to-date mozharness.