### PR TITLE
Upgrade all win10 worker types to use generic worker 8.3.0

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -641,7 +641,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -719,7 +719,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 8.3.0"
           }
         ]
       }


### PR DESCRIPTION
@grenade This fixes the black screenshot issue ([bug 1343580](https://bugzilla.mozilla.org/show_bug.cgi?id=1343580)).