### PR TITLE
Bug 1362594 - Disable indexing on all volumes on builders

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-1-b-win2012-gdt.json
+++ b/userdata/Manifest/gecko-1-b-win2012-gdt.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-1-b-win2016.json
+++ b/userdata/Manifest/gecko-1-b-win2016.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-3-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-3-b-win2012-beta.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -56,6 +56,11 @@
       ]
     },
     {
+      "ComponentName": "DisableIndexing",
+      "ComponentType": "DisableIndexing",
+      "Comment": "Disable indexing on all disk volumes (for performance)"
+    },
+    {
       "ComponentName": "ProcessExplorer",
       "ComponentType": "ZipInstall",
       "Comment": "Maintenance Toolchain - not essential for building firefox",


### PR DESCRIPTION
Filesystem indexing can hurt performance, interfere with various
processes (such as holding a handle on a file, preventing it from
being deleted), and offers no benefits to being enabled, at
least on the builders.

On testing machines, these statements are also likely true. However,
in some rare cases having indexing enabled may trigger conditions
that invalidate assumptions of tests, mainly that tests are running
on machines resembling what users run, which almost certainly have
indexing enabled. So this commit errors on the extreme side of
caution by not disabling indexing on test machines.