### PR TITLE
Set known folders (LocalAppData, LocalAppDataLow, RoamingAppData)

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -457,7 +457,9 @@
         "install",
         "startup",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--password",
+        "<PASSWORD>"
       ],
       "DependsOn": [
         {
@@ -1099,6 +1101,143 @@
         "state",
         "off"
       ]
+    },
+    {
+      "ComponentName": "KnownFolderDirectory",
+      "ComponentType": "DirectoryCreate",
+      "Path": "C:\\knownfolder"
+    },
+    {
+      "ComponentName": "KnownFolderDownload",
+      "ComponentType": "FileDownload",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "KnownFolderDirectory"
+        }
+      ],
+      "Source": "https://github.com/taskcluster/knownfolder/releases/download/v1.1.0/knownfolder-1.1.0-windows-amd64.exe",
+      "Target": "C:\\knownfolder\\knownfolder.exe"
+    },
+    {
+      "ComponentName": "GenericWorkerSetLocalAppData",
+      "ComponentType": "CommandRun",
+      "Command": "C:\\knownfolder\\knownfolder.exe",
+      "Arguments": [
+        "set",
+        "-u",
+        "GenericWorker",
+        "-p",
+        "<PASSWORD>",
+        "LocalAppData",
+        "Z:\\Users\\GenericWorker\\AppData\\Local"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        },
+        {
+          "ComponentType": "FileDownload",
+          "ComponentName": "KnownFolderDownload"
+        }
+      ],
+      "Validate": {
+        "CommandsReturn": [
+          {
+            "Command": "C:\\knownfolder\\knownfolder.exe",
+            "Arguments": [
+              "get",
+              "-u",
+              "GenericWorker",
+              "-p",
+              "<PASSWORD>",
+              "LocalAppData"
+            ],
+            "Match": "Z:\\Users\\GenericWorker\\AppData\\Local"
+          }
+        ]
+      }
+    },
+    {
+      "ComponentName": "GenericWorkerSetRoamingAppData",
+      "ComponentType": "CommandRun",
+      "Command": "C:\\knownfolder\\knownfolder.exe",
+      "Arguments": [
+        "set",
+        "-u",
+        "GenericWorker",
+        "-p",
+        "<PASSWORD>",
+        "LocalAppData",
+        "Z:\\Users\\GenericWorker\\AppData\\Roaming"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        },
+        {
+          "ComponentType": "FileDownload",
+          "ComponentName": "KnownFolderDownload"
+        }
+      ],
+      "Validate": {
+        "CommandsReturn": [
+          {
+            "Command": "C:\\knownfolder\\knownfolder.exe",
+            "Arguments": [
+              "get",
+              "-u",
+              "GenericWorker",
+              "-p",
+              "<PASSWORD>",
+              "RoamingAppData"
+            ],
+            "Match": "Z:\\Users\\GenericWorker\\AppData\\Roaming"
+          }
+        ]
+      }
+    },
+    {
+      "ComponentName": "GenericWorkerSetLocalAppDataLow",
+      "ComponentType": "CommandRun",
+      "Command": "C:\\knownfolder\\knownfolder.exe",
+      "Arguments": [
+        "set",
+        "-u",
+        "GenericWorker",
+        "-p",
+        "<PASSWORD>",
+        "LocalAppDataLow",
+        "Z:\\Users\\GenericWorker\\AppData\\LocalLow"
+      ],
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "GenericWorkerInstall"
+        },
+        {
+          "ComponentType": "FileDownload",
+          "ComponentName": "KnownFolderDownload"
+        }
+      ],
+      "Validate": {
+        "CommandsReturn": [
+          {
+            "Command": "C:\\knownfolder\\knownfolder.exe",
+            "Arguments": [
+              "get",
+              "-u",
+              "GenericWorker",
+              "-p",
+              "<PASSWORD>",
+              "LocalAppDataLow"
+            ],
+            "Match": "Z:\\Users\\GenericWorker\\AppData\\LocalLow"
+          }
+        ]
+      }
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -459,7 +459,7 @@
         "--config",
         "C:\\generic-worker\\generic-worker.config",
         "--password",
-        "<PASSWORD>"
+        "qazwsx123!@#QAZ"
       ],
       "DependsOn": [
         {
@@ -1128,7 +1128,7 @@
         "-u",
         "GenericWorker",
         "-p",
-        "<PASSWORD>",
+        "qazwsx123!@#QAZ",
         "LocalAppData",
         "Z:\\Users\\GenericWorker\\AppData\\Local"
       ],
@@ -1151,7 +1151,7 @@
               "-u",
               "GenericWorker",
               "-p",
-              "<PASSWORD>",
+              "qazwsx123!@#QAZ",
               "LocalAppData"
             ],
             "Match": "Z:\\Users\\GenericWorker\\AppData\\Local"
@@ -1168,7 +1168,7 @@
         "-u",
         "GenericWorker",
         "-p",
-        "<PASSWORD>",
+        "qazwsx123!@#QAZ",
         "LocalAppData",
         "Z:\\Users\\GenericWorker\\AppData\\Roaming"
       ],
@@ -1191,7 +1191,7 @@
               "-u",
               "GenericWorker",
               "-p",
-              "<PASSWORD>",
+              "qazwsx123!@#QAZ",
               "RoamingAppData"
             ],
             "Match": "Z:\\Users\\GenericWorker\\AppData\\Roaming"
@@ -1208,7 +1208,7 @@
         "-u",
         "GenericWorker",
         "-p",
-        "<PASSWORD>",
+        "qazwsx123!@#QAZ",
         "LocalAppDataLow",
         "Z:\\Users\\GenericWorker\\AppData\\LocalLow"
       ],
@@ -1231,7 +1231,7 @@
               "-u",
               "GenericWorker",
               "-p",
-              "<PASSWORD>",
+              "qazwsx123!@#QAZ",
               "LocalAppDataLow"
             ],
             "Match": "Z:\\Users\\GenericWorker\\AppData\\LocalLow"


### PR DESCRIPTION
When we run as task user, this is taken care of by generic worker, however when running as current user, generic worker can't influence the known folders, since they are determined when user profile is loaded, which is when generic worker user logs in (before generic worker process starts).

Fortunately, these known folders only need to be set once, after the generic worker user has been created. I created a tool for setting the known folder locations for an arbitrary user, and tested it on windows 10. It is working correctly.

There is one problem - we need to know the password of the generic worker account. Previously, we let generic worker program decide a password for us, randomly. I'm not sure best way to approach this. If we roll out to production, we'll need to decide a solution for this. Maybe we'll need to integrate setting known folder locations into the generic-worker install process itself.