### PR TITLE
Upgrade beta worker types to use generic-worker 9.3.0

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1039,7 +1039,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v9.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1105,11 +1105,11 @@
         ],
         "CommandsReturn": [
           {
-            "Command": "C:\\generic-worker\\generic-worker.exe",
+            Command": "C:\\generic-worker\\generic-worker.exe",
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 9.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1071,12 +1071,22 @@
       "Action": "Allow"
     },
     {
+      "ComponentName": "NSSMInstall",
+      "ComponentType": "ZipInstall",
+      "Comment": "NSSM is required to install Generic Worker as a service. Zip file contains top level nssm folder, so we can safely extract to C:\\.",
+      "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
+      "Destination": "C:\\",
+      "sha512": "d71e037b177f80fc1414e26cf183aefef7729079ea48a268f834b335cbc269005de7ae6e54155a8cec3663c503741fa4241172fa69e8fd9a5c07b3eb1b56eff2"
+    },
+    {
       "ComponentName": "GenericWorkerInstall",
       "ComponentType": "CommandRun",
       "Command": "C:\\generic-worker\\generic-worker.exe",
       "Arguments": [
         "install",
-        "startup",
+        "service",
+        "--nssm",
+        "C:\\nssm-2.24\\win64\\nssm.exe",
         "--config",
         "C:\\generic-worker\\generic-worker.config"
       ],
@@ -1096,6 +1106,10 @@
         {
           "ComponentType": "FirewallRule",
           "ComponentName": "LiveLog_Put"
+        },
+        {
+          "ComponentType": "NSSMInstall",
+          "ComponentName": "ZipInstall"
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1119,7 +1119,7 @@
         ],
         "CommandsReturn": [
           {
-            Command": "C:\\generic-worker\\generic-worker.exe",
+            "Command": "C:\\generic-worker\\generic-worker.exe",
             "Arguments": [
               "--version"
             ],

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.3.0/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v9.3.0/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -488,7 +488,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.3.0"
+            "Match": "generic-worker 9.3.0"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -450,12 +450,22 @@
       "Action": "Allow"
     },
     {
+      "ComponentName": "NSSMInstall",
+      "ComponentType": "ZipInstall",
+      "Comment": "NSSM is required to install Generic Worker as a service. Zip file contains top level nssm folder, so we can safely extract to C:\\.",
+      "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
+      "Destination": "C:\\",
+      "sha512": "d71e037b177f80fc1414e26cf183aefef7729079ea48a268f834b335cbc269005de7ae6e54155a8cec3663c503741fa4241172fa69e8fd9a5c07b3eb1b56eff2"
+    },
+    {
       "ComponentName": "GenericWorkerInstall",
       "ComponentType": "CommandRun",
       "Command": "C:\\generic-worker\\generic-worker.exe",
       "Arguments": [
         "install",
-        "startup",
+        "service",
+        "--nssm",
+        "C:\\nssm-2.24\\win64\\nssm.exe",
         "--config",
         "C:\\generic-worker\\generic-worker.config"
       ],
@@ -475,6 +485,10 @@
         {
           "ComponentType": "FirewallRule",
           "ComponentName": "LiveLog_Put"
+        },
+        {
+          "ComponentType": "NSSMInstall",
+          "ComponentName": "ZipInstall"
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -482,12 +482,22 @@
       "Action": "Allow"
     },
     {
+      "ComponentName": "NSSMInstall",
+      "ComponentType": "ZipInstall",
+      "Comment": "NSSM is required to install Generic Worker as a service. Zip file contains top level nssm folder, so we can safely extract to C:\\.",
+      "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
+      "Destination": "C:\\",
+      "sha512": "d71e037b177f80fc1414e26cf183aefef7729079ea48a268f834b335cbc269005de7ae6e54155a8cec3663c503741fa4241172fa69e8fd9a5c07b3eb1b56eff2"
+    },
+    {
       "ComponentName": "GenericWorkerInstall",
       "ComponentType": "CommandRun",
       "Command": "C:\\generic-worker\\generic-worker.exe",
       "Arguments": [
         "install",
-        "startup",
+        "service",
+        "--nssm",
+        "C:\\nssm-2.24\\win32\\nssm.exe",
         "--config",
         "C:\\generic-worker\\generic-worker.config"
       ],
@@ -507,6 +517,10 @@
         {
           "ComponentType": "FirewallRule",
           "ComponentName": "LiveLog_Put"
+        },
+        {
+          "ComponentType": "NSSMInstall",
+          "ComponentName": "ZipInstall"
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v8.2.0/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v9.3.0/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -520,7 +520,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 8.2.0"
+            "Match": "generic-worker 9.3.0"
           }
         ]
       }


### PR DESCRIPTION
This upgrades the beta worker types to use generic-worker 9.3.0 (which runs as a windows service, creates a user, and reboots into generated task user).