### PR TITLE
Remove SHA512 sums for NSSM

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1075,8 +1075,7 @@
       "ComponentType": "ZipInstall",
       "Comment": "NSSM is required to install Generic Worker as a service. Zip file contains top level nssm folder, so we can safely extract to C:\\.",
       "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
-      "Destination": "C:\\",
-      "sha512": "d71e037b177f80fc1414e26cf183aefef7729079ea48a268f834b335cbc269005de7ae6e54155a8cec3663c503741fa4241172fa69e8fd9a5c07b3eb1b56eff2"
+      "Destination": "C:\\"
     },
     {
       "ComponentName": "GenericWorkerInstall",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -454,8 +454,7 @@
       "ComponentType": "ZipInstall",
       "Comment": "NSSM is required to install Generic Worker as a service. Zip file contains top level nssm folder, so we can safely extract to C:\\.",
       "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
-      "Destination": "C:\\",
-      "sha512": "d71e037b177f80fc1414e26cf183aefef7729079ea48a268f834b335cbc269005de7ae6e54155a8cec3663c503741fa4241172fa69e8fd9a5c07b3eb1b56eff2"
+      "Destination": "C:\\"
     },
     {
       "ComponentName": "GenericWorkerInstall",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -486,8 +486,7 @@
       "ComponentType": "ZipInstall",
       "Comment": "NSSM is required to install Generic Worker as a service. Zip file contains top level nssm folder, so we can safely extract to C:\\.",
       "Url": "http://www.nssm.cc/release/nssm-2.24.zip",
-      "Destination": "C:\\",
-      "sha512": "d71e037b177f80fc1414e26cf183aefef7729079ea48a268f834b335cbc269005de7ae6e54155a8cec3663c503741fa4241172fa69e8fd9a5c07b3eb1b56eff2"
+      "Destination": "C:\\"
     },
     {
       "ComponentName": "GenericWorkerInstall",


### PR DESCRIPTION
Setting the `sha512` property implies that the binary is uploaded to tooltool. Once this becomes an accepted feature (i.e. we deploy to prod worker types, not betas), then I will make sure NSSM is published to tooltool (and check licence requirements etc).