### PR TITLE
ComponentName and ComponentType wrong way around for NSSM

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1107,8 +1107,8 @@
           "ComponentName": "LiveLog_Put"
         },
         {
-          "ComponentType": "ZipInstall"
-          "ComponentName": "NSSMInstall",
+          "ComponentType": "ZipInstall",
+          "ComponentName": "NSSMInstall"
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1107,8 +1107,8 @@
           "ComponentName": "LiveLog_Put"
         },
         {
-          "ComponentType": "NSSMInstall",
-          "ComponentName": "ZipInstall"
+          "ComponentType": "ZipInstall"
+          "ComponentName": "NSSMInstall",
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -486,8 +486,8 @@
           "ComponentName": "LiveLog_Put"
         },
         {
-          "ComponentType": "ZipInstall"
-          "ComponentName": "NSSMInstall",
+          "ComponentType": "ZipInstall",
+          "ComponentName": "NSSMInstall"
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -486,8 +486,8 @@
           "ComponentName": "LiveLog_Put"
         },
         {
-          "ComponentType": "NSSMInstall",
-          "ComponentName": "ZipInstall"
+          "ComponentType": "ZipInstall"
+          "ComponentName": "NSSMInstall",
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -518,8 +518,8 @@
           "ComponentName": "LiveLog_Put"
         },
         {
-          "ComponentType": "ZipInstall"
-          "ComponentName": "NSSMInstall",
+          "ComponentType": "ZipInstall",
+          "ComponentName": "NSSMInstall"
         }
       ],
       "Validate": {

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -518,8 +518,8 @@
           "ComponentName": "LiveLog_Put"
         },
         {
-          "ComponentType": "NSSMInstall",
-          "ComponentName": "ZipInstall"
+          "ComponentType": "ZipInstall"
+          "ComponentName": "NSSMInstall",
         }
       ],
       "Validate": {


### PR DESCRIPTION
This should fix the broken beta schemas.