### PR TITLE
Don't retry AMI generation tasks in CI - causes error InvalidAMINameDuplicate

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -82,6 +82,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:cot-gecko-1-b-win2012-beta
@@ -137,6 +138,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:cot-gecko-1-b-win2012
@@ -192,6 +194,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:cot-gecko-2-b-win2012
@@ -247,6 +250,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:cot-gecko-3-b-win2012
@@ -302,6 +306,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win7-32-cu
@@ -356,6 +361,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win7-32-beta
@@ -410,6 +416,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win7-32
@@ -464,6 +471,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win7-32-gpu
@@ -518,6 +526,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-cu
@@ -572,6 +581,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-beta
@@ -626,6 +636,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64
@@ -680,6 +691,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-gpu-b
@@ -734,6 +746,7 @@ tasks:
           source: '{{event.head.repo.url}}'
 
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
       scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:gecko-t-win10-64-gpu


### PR DESCRIPTION
Retries currently cause errors like:

```
An error occurred (InvalidAMIName.Duplicate) when calling the CreateImage operation: AMI name gecko-t-win7-32-cu version ce65a7230147 is already in use by AMI ami-6a335e0a
10:44 An error occurred (InvalidAMIName.Duplicate) when calling the CreateImage operation: AMI name gecko-t-win10-64-gpu-b version ce65a7230147 is already in use by AMI ami-160d6076
10:46 An error occurred (InvalidAMIName.Duplicate) when calling the CreateImage operation: AMI name gecko-t-win7-32-beta version ce65a7230147 is already in use by AMI ami-48325f28
```

This patch disables retries in the AMI generation tasks.

An alternative might be to check for an existing AMI and delete it first - but until then, this should be enough.