### PR TITLE
Bug 1380978 - upgrade generic-worker to 10.1.6 on gecko-{1,2,3}-b-win2012

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1039,7 +1039,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1147,7 +1147,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.0.5"
+            "Match": "generic-worker 10.1.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1039,7 +1039,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1147,7 +1147,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.0.5"
+            "Match": "generic-worker 10.1.6"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1039,7 +1039,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1147,7 +1147,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.0.5"
+            "Match": "generic-worker 10.1.6"
           }
         ]
       }


### PR DESCRIPTION
This fixes the issue whereby chain of trust artifacts were indexed in the chain of trust artifact by artifact path rather than artifact name.

Successfully [tested on try](https://treeherder.mozilla.org/#/jobs?repo=try&revision=c7bceb03cb6912502d50921406ca97b75ea5ab9b) using gecko-1-b-win2012-beta.

See [bug 1380978](https://bugzilla.mozilla.org/show_bug.cgi?id=1380978) for more details.

@grenade We can roll out in the morning when we're both around if you like - just wanted to get the PR out tonight.