### PR TITLE
Bug 1381768 - precache for robustcheckout; r?pmoore

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1241,8 +1241,14 @@
       "Comment": "required by firefox builds",
       "Command": "C:\\Program Files\\Mercurial\\hg.exe",
       "Arguments": [
-        "clone",
-        "-U",
+        "robustcheckout",
+        "--sharebase",
+        "Y:\\hg-shared",
+        "--purge",
+        "--upstream",
+        "https://hg.mozilla.org/mozilla-unified",
+        "--branch",
+        "default",
         "https://hg.mozilla.org/mozilla-central",
         "C:\\builds\\hg-shared\\mozilla-central"
       ],
@@ -1254,6 +1260,10 @@
         {
           "ComponentType": "DirectoryCreate",
           "ComponentName": "LegacyHgShared"
+        },
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "HgShared"
         }
       ],
       "Validate": {
@@ -1261,23 +1271,6 @@
           "C:\\builds\\hg-shared\\mozilla-central\\.hg"
         ]
       }
-    },
-    {
-      "ComponentName": "MozillaCentralCacheUpdate",
-      "ComponentType": "CommandRun",
-      "Comment": "keeps the cache up to date on subsequent runs/reboots",
-      "Command": "C:\\Program Files\\Mercurial\\hg.exe",
-      "Arguments": [
-        "pull",
-        "-R",
-        "C:\\builds\\hg-shared\\mozilla-central"
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "MozillaCentralCacheCreate"
-        }
-      ]
     },
     {
       "ComponentName": "CarbonClone",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1216,8 +1216,14 @@
       "Comment": "required by firefox builds",
       "Command": "C:\\Program Files\\Mercurial\\hg.exe",
       "Arguments": [
-        "clone",
-        "-U",
+        "robustcheckout",
+        "--sharebase",
+        "Y:\\hg-shared",
+        "--purge",
+        "--upstream",
+        "https://hg.mozilla.org/mozilla-unified",
+        "--branch",
+        "default",
         "https://hg.mozilla.org/mozilla-central",
         "C:\\builds\\hg-shared\\mozilla-central"
       ],
@@ -1229,6 +1235,10 @@
         {
           "ComponentType": "DirectoryCreate",
           "ComponentName": "LegacyHgShared"
+        },
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "HgShared"
         }
       ],
       "Validate": {
@@ -1236,23 +1246,6 @@
           "C:\\builds\\hg-shared\\mozilla-central\\.hg"
         ]
       }
-    },
-    {
-      "ComponentName": "MozillaCentralCacheUpdate",
-      "ComponentType": "CommandRun",
-      "Comment": "keeps the cache up to date on subsequent runs/reboots",
-      "Command": "C:\\Program Files\\Mercurial\\hg.exe",
-      "Arguments": [
-        "pull",
-        "-R",
-        "C:\\builds\\hg-shared\\mozilla-central"
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "MozillaCentralCacheCreate"
-        }
-      ]
     },
     {
       "ComponentName": "CarbonClone",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1216,8 +1216,14 @@
       "Comment": "required by firefox builds",
       "Command": "C:\\Program Files\\Mercurial\\hg.exe",
       "Arguments": [
-        "clone",
-        "-U",
+        "robustcheckout",
+        "--sharebase",
+        "Y:\\hg-shared",
+        "--purge",
+        "--upstream",
+        "https://hg.mozilla.org/mozilla-unified",
+        "--branch",
+        "default",
         "https://hg.mozilla.org/mozilla-central",
         "C:\\builds\\hg-shared\\mozilla-central"
       ],
@@ -1229,6 +1235,10 @@
         {
           "ComponentType": "DirectoryCreate",
           "ComponentName": "LegacyHgShared"
+        },
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "HgShared"
         }
       ],
       "Validate": {
@@ -1236,23 +1246,6 @@
           "C:\\builds\\hg-shared\\mozilla-central\\.hg"
         ]
       }
-    },
-    {
-      "ComponentName": "MozillaCentralCacheUpdate",
-      "ComponentType": "CommandRun",
-      "Comment": "keeps the cache up to date on subsequent runs/reboots",
-      "Command": "C:\\Program Files\\Mercurial\\hg.exe",
-      "Arguments": [
-        "pull",
-        "-R",
-        "C:\\builds\\hg-shared\\mozilla-central"
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "MozillaCentralCacheCreate"
-        }
-      ]
     },
     {
       "ComponentName": "CarbonClone",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1216,8 +1216,14 @@
       "Comment": "required by firefox builds",
       "Command": "C:\\Program Files\\Mercurial\\hg.exe",
       "Arguments": [
-        "clone",
-        "-U",
+        "robustcheckout",
+        "--sharebase",
+        "Y:\\hg-shared",
+        "--purge",
+        "--upstream",
+        "https://hg.mozilla.org/mozilla-unified",
+        "--branch",
+        "default",
         "https://hg.mozilla.org/mozilla-central",
         "C:\\builds\\hg-shared\\mozilla-central"
       ],
@@ -1229,6 +1235,10 @@
         {
           "ComponentType": "DirectoryCreate",
           "ComponentName": "LegacyHgShared"
+        },
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "HgShared"
         }
       ],
       "Validate": {
@@ -1236,23 +1246,6 @@
           "C:\\builds\\hg-shared\\mozilla-central\\.hg"
         ]
       }
-    },
-    {
-      "ComponentName": "MozillaCentralCacheUpdate",
-      "ComponentType": "CommandRun",
-      "Comment": "keeps the cache up to date on subsequent runs/reboots",
-      "Command": "C:\\Program Files\\Mercurial\\hg.exe",
-      "Arguments": [
-        "pull",
-        "-R",
-        "C:\\builds\\hg-shared\\mozilla-central"
-      ],
-      "DependsOn": [
-        {
-          "ComponentType": "CommandRun",
-          "ComponentName": "MozillaCentralCacheCreate"
-        }
-      ]
     },
     {
       "ComponentName": "CarbonClone",


### PR DESCRIPTION
this change ensures that y:\hg-shared contains a prepopulated robustcheckout sharebase during ami creation and hopefully reduces checkout time on the first task checkout for each spot instance derived from that ami.