### PR TITLE
bug 1384752 - prevent service stop failure, hanging loaner prep script

### DIFF
--- a/userdata/PrepLoaner.ps1
+++ b/userdata/PrepLoaner.ps1
@@ -137,12 +137,18 @@ function Remove-GenericWorker {
     $gwService = (Get-Service -Name 'Generic Worker' -ErrorAction SilentlyContinue)
     if (($gwService) -and ($gwService.Status -eq 'Running')) {
       Write-Log -message ('{0} :: attempting to stop running generic-worker service.' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
-      $gwService | Stop-Service -PassThru | Set-Service -StartupType disabled
+      $gwService | Stop-Service -Force -WarningAction SilentlyContinue
+      while((Get-Service -Name 'Generic Worker' -ErrorAction SilentlyContinue).State -ne 'Stopped') {
+        Write-Log -message ('{0} :: waiting for stopped state on generic-worker service.' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+        Start-Sleep -Seconds 2
+      }
+      Write-Log -message ('{0} :: generic-worker service stopped.' -f $($MyInvocation.MyCommand.Name)) -severity 'INFO'
+      (Get-WmiObject -Class Win32_Service -Filter "Name='Generic Worker'").delete()
       $gwService = (Get-Service -Name 'Generic Worker' -ErrorAction SilentlyContinue)
-      if (($gwService) -and ($gwService.Status -eq 'Running')) {
-        Write-Log -message ('{0} :: failed to stop running generic-worker service.' -f $($MyInvocation.MyCommand.Name)) -severity 'ERROR'
+      if ($gwService) {
+        Write-Log -message ('{0} :: failed to delete generic-worker service. current state: {1}.' -f $($MyInvocation.MyCommand.Name), $gwService.Status) -severity 'ERROR'
       } else {
-        Write-Log -message ('{0} :: generic-worker service stop initiated. current state: {1}.' -f $($MyInvocation.MyCommand.Name), $gwService.Status) -severity 'INFO'
+        Write-Log -message ('{0} :: generic-worker service deleted.' -f $($MyInvocation.MyCommand.Name)) -severity 'INFO'
       }
     }
     $gwProcess = (Get-Process | ? { $_.ProcessName -eq 'generic-worker' })


### PR DESCRIPTION
$gwService | Stop-Service -PassThru | Set-Service -StartupType disabled
this command was causing the script to hang or fail due to warnings about the service stop needing some time to complete. removed in favour of a more robust check.