### PR TITLE
bug 1396168 - firewall exceptions for task user apps

### DIFF
--- a/userdata/Configuration/GenericWorker/task-user-init-win7.cmd
+++ b/userdata/Configuration/GenericWorker/task-user-init-win7.cmd
@@ -1,8 +1,5 @@
 rem task user initialisation script
 
-rem auto hide task bar
-powershell -command "&{$p='HKCU:SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StuckRects3';$v=(Get-ItemProperty -Path $p).Settings;$v[8]=3;&Set-ItemProperty -Path $p -Name Settings -Value $v;&Stop-Process -ProcessName explorer}"
-
 rem task user firewall exceptions
 netsh advfirewall firewall add rule name="ssltunnel-%USERNAME%" dir=in action=allow program="%USERPROFILE%\build\tests\bin\ssltunnel.exe" enable=yes
 netsh advfirewall firewall add rule name="ssltunnel-%USERNAME%" dir=out action=allow program="%USERPROFILE%\build\tests\bin\ssltunnel.exe" enable=yes

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -856,6 +856,19 @@
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {
+      "ComponentName": "TaskUserInitScript",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "Bug 1261188 - initialisation script for new task users",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/task-user-init-win7.cmd",
+      "Target": "C:\\generic-worker\\task-user-init.cmd",
+      "DependsOn": [
+        {
+          "ComponentType": "DirectoryCreate",
+          "ComponentName": "GenericWorkerDirectory"
+        }
+      ]
+    },
+    {
       "ComponentName": "PipConfDirectory",
       "ComponentType": "DirectoryCreate",
       "Comment": "https://pip.pypa.io/en/stable/user_guide/#config-file",


### PR DESCRIPTION
- adds an init script for win 7
- includes in/out firewall exceptions for ssltunnel and python in the task user directories