### PR TITLE
Bug 1382204 - upgrade generic-worker to 10.2.2 to enable coalescing

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1029,7 +1029,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1137,7 +1137,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.1.6"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1029,7 +1029,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1137,7 +1137,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.1.6"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1029,7 +1029,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -1137,7 +1137,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.1.6"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -526,7 +526,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.1.6"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -418,7 +418,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -526,7 +526,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.0.5"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -649,7 +649,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.0.5/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -757,7 +757,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.0.5"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -450,7 +450,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -558,7 +558,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.1.6"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -714,7 +714,7 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.1.6/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.2.2/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe"
     },
     {
@@ -822,7 +822,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.1.6"
+            "Match": "generic-worker 10.2.2"
           }
         ]
       }


### PR DESCRIPTION
Hey guys,

In bug 1382204 I'm rolling out coalescing/superseding which is a feature in the newest generic-worker. This patch upgrades the worker types which are on earlier versions of generic-worker 10. Workers still on an older version of generic-worker (8.2.0 / 8.3.0) will be upgraded in a separate bug, once tests have been greened up.

Here are the [try results](https://treeherder.mozilla.org/#/jobs?repo=try&revision=250ac5aa0061c27a848e0679e315ffbca1414d51&group_state=expanded&selectedJob=130034277&filter-tier=1) which show failures on win7 gpu/win7 non-gpu/win10 non-gpu, but I believe not for win10 gpu tasks, and not for win2012 tasks.

Thanks!
Pete