### PR TITLE
Bug 1390271 - Upgrade Mercurial 3.9.1 -> 4.3.1 on windows workers

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -569,11 +569,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390310",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.1-x64.msi",
-      "Name": "Mercurial 4.3.1 (x64)",
-      "ProductId": "83036929-F1B7-411E-9AFA-E31742848AD4",
-      "sha512": "ba6c830ef61d91073e48c902566c95c2ed0d4673585ff2899469afc6dc49a578d8eae12b57ecd2cd2319b091a31f9967f5d08c8d73ac9c60a8695a3e1b335bd0"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -569,11 +569,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390310",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.1-x64.msi",
-      "Name": "Mercurial 4.3.1 (x64)",
-      "ProductId": "83036929-F1B7-411E-9AFA-E31742848AD4",
-      "sha512": "ba6c830ef61d91073e48c902566c95c2ed0d4673585ff2899469afc6dc49a578d8eae12b57ecd2cd2319b091a31f9967f5d08c8d73ac9c60a8695a3e1b335bd0"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -569,11 +569,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390310",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.1-x64.msi",
-      "Name": "Mercurial 4.3.1 (x64)",
-      "ProductId": "83036929-F1B7-411E-9AFA-E31742848AD4",
-      "sha512": "ba6c830ef61d91073e48c902566c95c2ed0d4673585ff2899469afc6dc49a578d8eae12b57ecd2cd2319b091a31f9967f5d08c8d73ac9c60a8695a3e1b335bd0"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -569,11 +569,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390310",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.1-x64.msi",
-      "Name": "Mercurial 4.3.1 (x64)",
-      "ProductId": "83036929-F1B7-411E-9AFA-E31742848AD4",
-      "sha512": "ba6c830ef61d91073e48c902566c95c2ed0d4673585ff2899469afc6dc49a578d8eae12b57ecd2cd2319b091a31f9967f5d08c8d73ac9c60a8695a3e1b335bd0"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -272,23 +272,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -296,7 +285,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -321,7 +310,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -351,7 +340,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -747,7 +736,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -272,23 +272,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -296,7 +285,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -321,7 +310,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -351,7 +340,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -747,7 +736,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -272,23 +272,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -296,7 +285,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -321,7 +310,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -351,7 +340,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -755,7 +744,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -272,23 +272,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -296,7 +285,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -321,7 +310,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -351,7 +340,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -723,7 +712,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -514,23 +514,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -538,7 +527,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -563,7 +552,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -593,7 +582,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -977,7 +966,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -272,23 +272,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1-x64.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1-x64.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "b71fd8f1d1e578bbd26b7bc6635d4a9d11320bce36f24ba44152cba3c02477006ab8d6fd9b06b263d11b4327713a048156d64bcbbb073d95eede0a53675a9a80"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x64.msi",
+      "Name": "Mercurial 4.3.3 (x64)",
+      "ProductId": "D08D4000-DDF1-4FCA-A07E-C4898650EB0D",
+      "sha512": "67453A2E28DE4C4D6A8EDE3878B96A4DF02A3C01E3E2CA5C550381FA11867A46876957F76BD812EBF33F072161A6033CE2EAADAF281CE12238861685AAB47F6B"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -296,7 +285,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -321,7 +310,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -351,7 +340,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -709,7 +698,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -304,23 +304,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x86.msi",
+      "Name": "Mercurial 4.3.3 (x86)",
+      "ProductId": "49831801-1706-46C0-895F-3921F178655B",
+      "sha512": "AC082797459E9795AC1B18369D804485AA2CB1EB1F1135F49C89CCCB2B2F2634C96BDE30CBB2BD0CD4F725E058CC43146142C2DDE27EB8EDA790FD469E45E4E0"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -328,7 +317,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -353,7 +342,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -383,7 +372,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -763,7 +752,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -304,23 +304,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x86.msi",
+      "Name": "Mercurial 4.3.3 (x86)",
+      "ProductId": "49831801-1706-46C0-895F-3921F178655B",
+      "sha512": "AC082797459E9795AC1B18369D804485AA2CB1EB1F1135F49C89CCCB2B2F2634C96BDE30CBB2BD0CD4F725E058CC43146142C2DDE27EB8EDA790FD469E45E4E0"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -328,7 +317,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -353,7 +342,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -383,7 +372,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -763,7 +752,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win7-32-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu-b.json
@@ -304,23 +304,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x86.msi",
+      "Name": "Mercurial 4.3.3 (x86)",
+      "ProductId": "49831801-1706-46C0-895F-3921F178655B",
+      "sha512": "AC082797459E9795AC1B18369D804485AA2CB1EB1F1135F49C89CCCB2B2F2634C96BDE30CBB2BD0CD4F725E058CC43146142C2DDE27EB8EDA790FD469E45E4E0"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -328,7 +317,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -353,7 +342,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -383,7 +372,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -763,7 +752,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -304,23 +304,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x86.msi",
+      "Name": "Mercurial 4.3.3 (x86)",
+      "ProductId": "49831801-1706-46C0-895F-3921F178655B",
+      "sha512": "AC082797459E9795AC1B18369D804485AA2CB1EB1F1135F49C89CCCB2B2F2634C96BDE30CBB2BD0CD4F725E058CC43146142C2DDE27EB8EDA790FD469E45E4E0"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -328,7 +317,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -353,7 +342,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -383,7 +372,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -725,7 +714,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -568,23 +568,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x86.msi",
+      "Name": "Mercurial 4.3.3 (x86)",
+      "ProductId": "49831801-1706-46C0-895F-3921F178655B",
+      "sha512": "AC082797459E9795AC1B18369D804485AA2CB1EB1F1135F49C89CCCB2B2F2634C96BDE30CBB2BD0CD4F725E058CC43146142C2DDE27EB8EDA790FD469E45E4E0"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -592,7 +581,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -617,7 +606,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -647,7 +636,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -1040,7 +1029,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -304,23 +304,12 @@
     },
     {
       "ComponentName": "Mercurial",
-      "ComponentType": "ExeInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1298976",
-      "Url": "https://www.mercurial-scm.org/release/windows/Mercurial-3.9.1.exe",
-      "Arguments": [
-        "/SP-",
-        "/VERYSILENT",
-        "/NORESTART",
-        "/DIR=expand:{pf}\\Mercurial",
-        "/LOG=\"C:\\log\\Mercurial-3.9.1.exe.install.log\""
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\Mercurial\\hg.exe",
-          "C:\\Program Files\\Mercurial\\python27.dll"
-        ]
-      },
-      "sha512": "a4a70ac81252605ba0856884d0cce6423b1557c8f6efe2f29c4f4b1c7a057de8d82e2074bd55d9b7562023e47ae55397c6632c3cff06e706c0271c8f2474af60"
+      "ComponentType": "MsiInstall",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1390271",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.3.3-x86.msi",
+      "Name": "Mercurial 4.3.3 (x86)",
+      "ProductId": "49831801-1706-46C0-895F-3921F178655B",
+      "sha512": "AC082797459E9795AC1B18369D804485AA2CB1EB1F1135F49C89CCCB2B2F2634C96BDE30CBB2BD0CD4F725E058CC43146142C2DDE27EB8EDA790FD469E45E4E0"
     },
     {
       "ComponentName": "MercurialConfig",
@@ -328,7 +317,7 @@
       "Comment": "Required by clonebundle and share hg extensions",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -353,7 +342,7 @@
       "ComponentType": "ChecksumFileDownload",
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -383,7 +372,7 @@
           "ComponentName": "MozillaBuildSetup"
         },
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],
@@ -725,7 +714,7 @@
       ],
       "DependsOn": [
         {
-          "ComponentType": "ExeInstall",
+          "ComponentType": "MsiInstall",
           "ComponentName": "Mercurial"
         }
       ],


### PR DESCRIPTION
This upgrades mercurial on all the windows worker types to 4.3.1 from 3.9.1 that they were previously on.

Untested.