### PR TITLE
Update PATH following MozillaBuild update

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -471,7 +471,7 @@
           "C:\\mozilla-build\\msys\\local\\bin\\make.exe",
           "C:\\mozilla-build\\msys\\local\\bin\\autoconf-2.13",
           "C:\\mozilla-build\\python\\python.exe",
-          "C:\\mozilla-build\\upx391w\\upx.exe",
+          "C:\\mozilla-build\\upx394w\\upx.exe",
           "C:\\mozilla-build\\yasm\\yasm.exe"
         ],
         "FilesContain": [
@@ -977,11 +977,9 @@
         "C:\\mozilla-build\\msys\\bin",
         "C:\\mozilla-build\\msys\\local\\bin",
         "C:\\mozilla-build\\nsis-3.01",
-        "C:\\mozilla-build\\nsis-3.0b3",
-        "C:\\mozilla-build\\nsis-2.46u",
         "C:\\mozilla-build\\python",
         "C:\\mozilla-build\\python\\Scripts",
-        "C:\\mozilla-build\\upx391w",
+        "C:\\mozilla-build\\upx394w",
         "C:\\mozilla-build\\wget",
         "C:\\mozilla-build\\yasm"
       ],

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -225,7 +225,7 @@
           "C:\\mozilla-build\\msys\\local\\bin\\make.exe",
           "C:\\mozilla-build\\msys\\local\\bin\\autoconf-2.13",
           "C:\\mozilla-build\\python\\python.exe",
-          "C:\\mozilla-build\\upx391w\\upx.exe",
+          "C:\\mozilla-build\\upx394w\\upx.exe",
           "C:\\mozilla-build\\yasm\\yasm.exe"
         ],
         "FilesContain": [
@@ -356,11 +356,10 @@
         "C:\\mozilla-build\\mozmake",
         "C:\\mozilla-build\\msys\\bin",
         "C:\\mozilla-build\\msys\\local\\bin",
-        "C:\\mozilla-build\\nsis-3.0b3",
-        "C:\\mozilla-build\\nsis-2.46u",
+        "C:\\mozilla-build\\nsis-3.01",
         "C:\\mozilla-build\\python",
         "C:\\mozilla-build\\python\\Scripts",
-        "C:\\mozilla-build\\upx391w",
+        "C:\\mozilla-build\\upx394w",
         "C:\\mozilla-build\\wget",
         "C:\\mozilla-build\\yasm"
       ],

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -225,7 +225,7 @@
           "C:\\mozilla-build\\msys\\local\\bin\\make.exe",
           "C:\\mozilla-build\\msys\\local\\bin\\autoconf-2.13",
           "C:\\mozilla-build\\python\\python.exe",
-          "C:\\mozilla-build\\upx391w\\upx.exe",
+          "C:\\mozilla-build\\upx394w\\upx.exe",
           "C:\\mozilla-build\\yasm\\yasm.exe"
         ],
         "FilesContain": [
@@ -356,11 +356,10 @@
         "C:\\mozilla-build\\mozmake",
         "C:\\mozilla-build\\msys\\bin",
         "C:\\mozilla-build\\msys\\local\\bin",
-        "C:\\mozilla-build\\nsis-3.0b3",
-        "C:\\mozilla-build\\nsis-2.46u",
+        "C:\\mozilla-build\\nsis-3.01",
         "C:\\mozilla-build\\python",
         "C:\\mozilla-build\\python\\Scripts",
-        "C:\\mozilla-build\\upx391w",
+        "C:\\mozilla-build\\upx394w",
         "C:\\mozilla-build\\wget",
         "C:\\mozilla-build\\yasm"
       ],


### PR DESCRIPTION
We can probably stop installing nsis-3.01 in the build machine now that MozillaBuild installs it, but I'd rather do that separately and test this first.