### PR TITLE
Removed NSSMDownload where it isn't needed

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -472,12 +472,6 @@
       }
     },
     {
-      "ComponentName": "NSSMDownload",
-      "ComponentType": "FileDownload",
-      "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
-      "Target": "C:\\Windows\\Temp\\NSSMInstall.zip"
-    },
-    {
       "ComponentName": "GenericWorkerInstall",
       "ComponentType": "CommandRun",
       "Command": "C:\\generic-worker\\generic-worker.exe",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -440,12 +440,6 @@
       "Action": "Allow"
     },
     {
-      "ComponentName": "NSSMDownload",
-      "ComponentType": "FileDownload",
-      "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
-      "Target": "C:\\Windows\\Temp\\NSSMInstall.zip"
-    },
-    {
       "ComponentName": "GenericWorkerInstall",
       "ComponentType": "CommandRun",
       "Command": "C:\\generic-worker\\generic-worker.exe",


### PR DESCRIPTION
`NSSMDownload` was duplicated in `gecko-t-win10-64-gpu-b` (so could be removed) and also appeared in `gecko-t-win10-64-gpu` but is not needed as it runs `generic-worker 8.3.0` which isn't installed as a Windows service.