### PR TITLE
Upgraded level 2,3 workers to MozillaBuild 3.1

### DIFF
--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -462,7 +462,7 @@
         "/S",
         "/D=C:\\mozilla-build"
       ],
-      "Url": "http://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-2.2.0.exe",
+      "Url": "http://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.1.exe",
       "Validate": {
         "PathsExist": [
           "C:\\mozilla-build\\info-zip\\unzip.exe",
@@ -471,67 +471,17 @@
           "C:\\mozilla-build\\msys\\local\\bin\\make.exe",
           "C:\\mozilla-build\\msys\\local\\bin\\autoconf-2.13",
           "C:\\mozilla-build\\python\\python.exe",
-          "C:\\mozilla-build\\upx391w\\upx.exe",
+          "C:\\mozilla-build\\upx394w\\upx.exe",
           "C:\\mozilla-build\\yasm\\yasm.exe"
         ],
         "FilesContain": [
           {
             "Path": "C:\\mozilla-build\\VERSION",
-            "Match": "2.2.0"
+            "Match": "3.1"
           }
         ]
       },
-      "sha512": "b593aa4ed9ff34bd4a20860fec478b3638ff1f916a60dc79ebcff46cee279fdb59dd53a36579378f0e11f4be201114578a429bfbfc11eda195a0b1db7aa9831e"
-    },
-    {
-      "ComponentName": "NsisInstall",
-      "ComponentType": "ExeInstall",
-      "Comment": "Bug 1236624 - NSIS 3.01",
-      "Arguments": [
-        "/S",
-        "/D=C:\\mozilla-build\\nsis-3.01"
-      ],
-      "Url": "http://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01-setup.exe?r=http%3A%2F%2Fnsis.sourceforge.net%2FDownload&ts=1484218481&use_mirror=kent",
-      "Validate": {
-        "PathsExist": [
-          "C:\\mozilla-build\\nsis-3.01\\NSIS.exe",
-          "C:\\mozilla-build\\nsis-3.01\\makensis.exe",
-          "C:\\mozilla-build\\nsis-3.01\\makensisw.exe"
-        ]
-      },
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "MozillaBuildSetup"
-        }
-      ],
-      "sha512": "03edd9831b928591a2133c6445e43378c5c77985224106197dadaed7c68e484838367434f5fe949c5971dcb6667a40acdb9b1e114f41b476dfebc080da5115a6"
-    },
-    {
-      "ComponentName": "makensis_301",
-      "ComponentType": "SymbolicLink",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1236624#c53",
-      "Target": "C:\\mozilla-build\\nsis-3.01\\makensis.exe",
-      "Link": "C:\\mozilla-build\\nsis-3.01\\makensis-3.01.exe",
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "NsisInstall"
-        }
-      ]
-    },
-    {
-      "ComponentName": "bin_makensis_301",
-      "ComponentType": "SymbolicLink",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1236624#c53",
-      "Target": "C:\\mozilla-build\\nsis-3.01\\Bin\\makensis.exe",
-      "Link": "C:\\mozilla-build\\nsis-3.01\\Bin\\makensis-3.01.exe",
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "NsisInstall"
-        }
-      ]
+      "sha512": "24312d28297b44e802069702628806d2c7f2c3e6ba536be1ab66caf08d8a818cfbcf861ef32cff88eb4275d25d66f376ae96af423e2a979bf729071b157b4dd2"
     },
     {
       "ComponentName": "msys_home",
@@ -998,11 +948,9 @@
         "C:\\mozilla-build\\msys\\bin",
         "C:\\mozilla-build\\msys\\local\\bin",
         "C:\\mozilla-build\\nsis-3.01",
-        "C:\\mozilla-build\\nsis-3.0b3",
-        "C:\\mozilla-build\\nsis-2.46u",
         "C:\\mozilla-build\\python",
         "C:\\mozilla-build\\python\\Scripts",
-        "C:\\mozilla-build\\upx391w",
+        "C:\\mozilla-build\\upx394w",
         "C:\\mozilla-build\\wget",
         "C:\\mozilla-build\\yasm"
       ],

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -462,7 +462,7 @@
         "/S",
         "/D=C:\\mozilla-build"
       ],
-      "Url": "http://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-2.2.0.exe",
+      "Url": "http://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.1.exe",
       "Validate": {
         "PathsExist": [
           "C:\\mozilla-build\\info-zip\\unzip.exe",
@@ -471,67 +471,17 @@
           "C:\\mozilla-build\\msys\\local\\bin\\make.exe",
           "C:\\mozilla-build\\msys\\local\\bin\\autoconf-2.13",
           "C:\\mozilla-build\\python\\python.exe",
-          "C:\\mozilla-build\\upx391w\\upx.exe",
+          "C:\\mozilla-build\\upx394w\\upx.exe",
           "C:\\mozilla-build\\yasm\\yasm.exe"
         ],
         "FilesContain": [
           {
             "Path": "C:\\mozilla-build\\VERSION",
-            "Match": "2.2.0"
+            "Match": "3.1"
           }
         ]
       },
-      "sha512": "b593aa4ed9ff34bd4a20860fec478b3638ff1f916a60dc79ebcff46cee279fdb59dd53a36579378f0e11f4be201114578a429bfbfc11eda195a0b1db7aa9831e"
-    },
-    {
-      "ComponentName": "NsisInstall",
-      "ComponentType": "ExeInstall",
-      "Comment": "Bug 1236624 - NSIS 3.01",
-      "Arguments": [
-        "/S",
-        "/D=C:\\mozilla-build\\nsis-3.01"
-      ],
-      "Url": "http://downloads.sourceforge.net/project/nsis/NSIS%203/3.01/nsis-3.01-setup.exe?r=http%3A%2F%2Fnsis.sourceforge.net%2FDownload&ts=1484218481&use_mirror=kent",
-      "Validate": {
-        "PathsExist": [
-          "C:\\mozilla-build\\nsis-3.01\\NSIS.exe",
-          "C:\\mozilla-build\\nsis-3.01\\makensis.exe",
-          "C:\\mozilla-build\\nsis-3.01\\makensisw.exe"
-        ]
-      },
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "MozillaBuildSetup"
-        }
-      ],
-      "sha512": "03edd9831b928591a2133c6445e43378c5c77985224106197dadaed7c68e484838367434f5fe949c5971dcb6667a40acdb9b1e114f41b476dfebc080da5115a6"
-    },
-    {
-      "ComponentName": "makensis_301",
-      "ComponentType": "SymbolicLink",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1236624#c53",
-      "Target": "C:\\mozilla-build\\nsis-3.01\\makensis.exe",
-      "Link": "C:\\mozilla-build\\nsis-3.01\\makensis-3.01.exe",
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "NsisInstall"
-        }
-      ]
-    },
-    {
-      "ComponentName": "bin_makensis_301",
-      "ComponentType": "SymbolicLink",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1236624#c53",
-      "Target": "C:\\mozilla-build\\nsis-3.01\\Bin\\makensis.exe",
-      "Link": "C:\\mozilla-build\\nsis-3.01\\Bin\\makensis-3.01.exe",
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "NsisInstall"
-        }
-      ]
+      "sha512": "24312d28297b44e802069702628806d2c7f2c3e6ba536be1ab66caf08d8a818cfbcf861ef32cff88eb4275d25d66f376ae96af423e2a979bf729071b157b4dd2"
     },
     {
       "ComponentName": "msys_home",
@@ -998,11 +948,9 @@
         "C:\\mozilla-build\\msys\\bin",
         "C:\\mozilla-build\\msys\\local\\bin",
         "C:\\mozilla-build\\nsis-3.01",
-        "C:\\mozilla-build\\nsis-3.0b3",
-        "C:\\mozilla-build\\nsis-2.46u",
         "C:\\mozilla-build\\python",
         "C:\\mozilla-build\\python\\Scripts",
-        "C:\\mozilla-build\\upx391w",
+        "C:\\mozilla-build\\upx394w",
         "C:\\mozilla-build\\wget",
         "C:\\mozilla-build\\yasm"
       ],


### PR DESCRIPTION
This aligns `gecko-{2,3}-b-win2012` with `gecko-1-b-win2012`.