### PR TITLE
Signing key cot.key now required on all worker types, not just builders

### DIFF
--- a/userdata/Configuration/GenericWorker/generic-worker.config
+++ b/userdata/Configuration/GenericWorker/generic-worker.config
@@ -7,6 +7,7 @@
   "livelogKey": "C:\\generic-worker\\livelog.key",
   "sentryProject": "generic-worker",
   "shutdownMachineOnInternalError": true,
+  "signingKeyLocation": "C:\\generic-worker\\cot.key",
   "subdomain": "taskcluster-worker.net",
   "tasksDir": "Z:\\"
 }

--- a/userdata/rundsc.ps1
+++ b/userdata/rundsc.ps1
@@ -1116,8 +1116,8 @@ if ($rebootReasons.length) {
             Write-Log -message 'cot key intervention failed. awaiting timeout or cancellation.' -severity 'ERROR'
           }
         }
-        # level 1 and 2 builders can generate new keys. these don't require trust from cot repo
-        '^gecko-[12]-b-win2012(-beta)?$' {
+        # all other workers can generate new keys. these don't require trust from cot repo
+        default {
           if (-not (Test-Path -Path 'C:\generic-worker\cot.key' -ErrorAction SilentlyContinue)) {
             Write-Log -message 'cot key missing. generating key.' -severity 'WARN'
             & 'C:\generic-worker\generic-worker.exe' @('new-openpgp-keypair', '--file', 'C:\generic-worker\cot.key') | Out-File -filePath $logFile -append
@@ -1133,9 +1133,6 @@ if ($rebootReasons.length) {
           } else {
             Write-Log -message 'cot key missing. awaiting timeout or cancellation.' -severity 'INFO'
           }
-        }
-        # testers don't need keys
-        default {
           if (@(Get-Process | ? { $_.ProcessName -eq 'rdpclip' }).length -eq 0) {
             & shutdown @('-s', '-t', '0', '-c', 'dsc run complete', '-f', '-d', 'p:4:1') | Out-File -filePath $logFile -append
           }

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -654,8 +654,7 @@ Configuration xDynamicConfig {
       }
     }
   }
-  $builderWorkerTypes = @('gecko-1-b-win2012', 'gecko-1-b-win2012-beta', 'gecko-2-b-win2012', 'gecko-3-b-win2012')
-  if (($locationType -eq 'AWS') -and ($workerType) -and $builderWorkerTypes.Contains($workerType)) {
+  if (($locationType -eq 'AWS') -and ($workerType)) {
     Script CotGpgKeyImport {
       DependsOn = @('[Script]InstallSupportingModules', '[Script]ExeInstall_GpgForWin', '[File]DirectoryCreate_GenericWorkerDirectory')
       GetScript = "@{ Script = CotGpgKeyImport }"


### PR DESCRIPTION
Hey Rob,

Since [bug 1358545](https://bugzilla.mozilla.org/show_bug.cgi?id=1358545#c0) we now have startup checks that a signing key is present, and not readable by task users. This PR adds a chain of trust key generation for non-builders.

Note, the name of the feature "chain of trust" is mildly misleading here, since the feature is really "signed artifacts". It just so happens the primary use case of having signed artifacts is for chain of trust validation - but being able to sign artifacts for any task is a generally useful thing, as it provides some assurance that the artifact has not been tampered with, which is why it also useful to have on testers, even if we don't do chain-of-trust verification on test artifacts.

Thanks!
Pete