### PR TITLE
set numberOfTasksToRun to 0 in gw 10 otherwise no new users will get created

### DIFF
--- a/userdata/Configuration/GenericWorker/generic-worker.config
+++ b/userdata/Configuration/GenericWorker/generic-worker.config
@@ -5,6 +5,7 @@
   "livelogCertificate": "C:\\generic-worker\\livelog.crt",
   "livelogExecutable": "C:\\generic-worker\\livelog.exe",
   "livelogKey": "C:\\generic-worker\\livelog.key",
+  "numberOfTasksToRun": 0,
   "sentryProject": "generic-worker",
   "shutdownMachineOnInternalError": true,
   "signingKeyLocation": "C:\\generic-worker\\cot.key",


### PR DESCRIPTION
If `numberOfTasksToRun` is e.g. `1`, no new user will get created after the task runs, so each task will run under the same user.

Note this change only affects generic worker 10 deployments.