### PR TITLE
Bug 1365909 - explicitly disable windows defender

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1151,6 +1151,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1151,6 +1151,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1203,6 +1203,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1203,6 +1203,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1263,6 +1263,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1151,6 +1151,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -1192,6 +1192,22 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -1192,6 +1192,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win7-32-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu-b.json
@@ -1192,6 +1192,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -1192,6 +1192,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -1221,6 +1221,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -1192,6 +1192,14 @@
       "ValueName": "PreferredPlan",
       "ValueType": "String",
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+    },
+    {
+      "ComponentName": "DisableWinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
+      "Name": "WinDefend",
+      "StartupType": "Disabled",
+      "State": "Stopped"
     }
   ]
 }


### PR DESCRIPTION
rather than rely on windows defender being disabled in the base ami, include a manifest component which explicitly disables it