### PR TITLE
Don't create C:\dsc\task-claim-state.valid immediately before rebooting worker

### DIFF
--- a/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot-beta.bat
+++ b/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot-beta.bat
@@ -50,8 +50,6 @@ goto End
 if exist Z:\loan logoff /f /n
 if exist Z:\loan goto End
 format Z: /fs:ntfs /v:"task" /q /y
-echo Creating file C:\dsc\task-claim-state.valid >> .\generic-worker.log
-<nul (set/p z=) >C:\dsc\task-claim-state.valid
 shutdown /r /t 0 /f /c "Rebooting as generic worker ran successfully"
 
 :End

--- a/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat
+++ b/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat
@@ -55,8 +55,6 @@ goto End
 if exist Z:\loan logoff /f /n
 if exist Z:\loan goto End
 format Z: /fs:ntfs /v:"task" /q /y
-echo Creating file C:\dsc\task-claim-state.valid >> .\generic-worker.log
-<nul (set/p z=) >C:\dsc\task-claim-state.valid
 shutdown /r /t 0 /f /c "rebooting; generic worker task run completed" /d p:4:1
 
 :End


### PR DESCRIPTION
This will solve the issue, if we are sure [this line](https://github.com/mozilla-releng/OpenCloudConfig/blob/dbd82051b22f3cd336153d257f5509bf838652d0/userdata/rundsc.ps1#L1204) is run at the end of an OCC run. Rob, can you confirm if that is the case?

The problem was that `C:\dsc\task-claim-state.valid` file was being created before OCC has run, but since it is used to signal that generic worker can be started, it should only be created when OCC completes. Probably that is the case already, so we can just delete the creation in `run-generic-worker.bat`.

Note an alternative fix could be for the "Generic Worker" service not to auto start, but to be manually started when OCC has completed.