### PR TITLE
Bug 1457416 - roll back ami deployments with commit syntax

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -84,6 +84,55 @@ tasks:
     - provisionerId: '{{taskcluster.docker.provisionerId}}'
       retries: 0
       scopes:
+          - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
+          - aws-provisioner:manage-worker-type:gecko-1-b-win2012
+          - aws-provisioner:manage-worker-type:gecko-1-b-win2012-beta
+          - aws-provisioner:manage-worker-type:gecko-2-b-win2012
+          - aws-provisioner:manage-worker-type:gecko-3-b-win2012
+          - aws-provisioner:manage-worker-type:gecko-t-win7-32
+          - aws-provisioner:manage-worker-type:gecko-t-win7-32-beta
+          - aws-provisioner:manage-worker-type:gecko-t-win7-32-cu
+          - aws-provisioner:manage-worker-type:gecko-t-win7-32-gpu
+          - aws-provisioner:manage-worker-type:gecko-t-win7-32-gpu-b
+          - aws-provisioner:manage-worker-type:gecko-t-win10-64
+          - aws-provisioner:manage-worker-type:gecko-t-win10-64-beta
+          - aws-provisioner:manage-worker-type:gecko-t-win10-64-cu
+          - aws-provisioner:manage-worker-type:gecko-t-win10-64-gpu
+          - aws-provisioner:manage-worker-type:gecko-t-win10-64-gpu-b
+      routes:
+          - 'index.project.releng.opencloudconfig.v1.revision.{{event.head.sha}}.rollback'
+      workerType: '{{taskcluster.docker.workerType}}'
+      extra:
+          github:
+              env: true
+              events:
+                  - push
+              branches:
+                - master
+          data:
+              head:
+                  sha: '{{event.head.sha}}'
+                  user:
+                      email: '{{event.head.user.email}}'
+      payload:
+          maxRunTime: 1200
+          image: 'grenade/opencloudconfig'
+          features:
+              taskclusterProxy: true
+          command:
+              - '/bin/bash'
+              - '--login'
+              - '-c'
+              - 'git clone --quiet {{event.head.repo.url}} && python ./OpenCloudConfig/ci/rollback.py'
+      metadata:
+          name: 'Rollback'
+          description: 'Roll back AMIs and TaskCluster AWS Provisoner config for a given worker type when requested in commit syntax'
+          owner: '{{event.head.user.email}}'
+          source: '{{event.head.repo.url}}'
+
+    - provisionerId: '{{taskcluster.docker.provisionerId}}'
+      retries: 0
+      scopes:
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updatetooltoolrepo
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype
           - secrets:get:repo:github.com/mozilla-releng/OpenCloudConfig:cot-gecko-1-b-win2012-beta

--- a/ci/rollback.py
+++ b/ci/rollback.py
@@ -1,13 +1,33 @@
+import boto3
+import json
 import requests
+import os.path
+from ConfigParser import ConfigParser
 
 
 def get_aws_creds():
-  """
-  fetch aws credentials from taskcluster secrets
-  """
-  url = 'http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype'
-  s = requests.get(url).json().secret
-  return s.aws_tc_account_id, s.TASKCLUSTER_AWS_ACCESS_KEY, s.TASKCLUSTER_AWS_SECRET_KEY
+    """
+    fetch aws credentials
+    - from taskcluster secrets when running as a taskcluster github job
+    - from aws credentials file when debugging
+    """
+    credentials_config = os.path.join(os.path.expanduser('~'), '.aws', 'credentials')
+    if os.path.isfile(credentials_config):
+        config = ConfigParser()
+        config.read(credentials_config)
+        return config.get('occ-taskcluster', 'aws_account_id'), config.get('occ-taskcluster', 'aws_access_key_id'), config.get('occ-taskcluster', 'aws_secret_access_key')
+
+    url = 'http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype'
+    s = requests.get(url).json().secret
+    return s.aws_tc_account_id, s.TASKCLUSTER_AWS_ACCESS_KEY, s.TASKCLUSTER_AWS_SECRET_KEY
 
 
-account_id, access_key, secret_key = get_aws_creds()
+aws_account_id, aws_access_key_id, aws_secret_access_key = get_aws_creds()
+boto3.setup_default_session(
+    aws_access_key_id=aws_access_key_id,
+    aws_secret_access_key=aws_secret_access_key)
+ec2 = boto3.client('ec2')
+response = ec2.describe_images(
+    Owners=[aws_account_id],
+    Filters=[{'Name':'name', 'Values':['gecko-*-b-win* version *', 'gecko-t-win* version *']}])
+print json.dumps(response, indent=2, sort_keys=True)

--- a/ci/rollback.py
+++ b/ci/rollback.py
@@ -1,0 +1,13 @@
+import requests
+
+
+def get_aws_creds():
+  """
+  fetch aws credentials from taskcluster secrets
+  """
+  url = 'http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype'
+  s = requests.get(url).json().secret
+  return s.aws_tc_account_id, s.TASKCLUSTER_AWS_ACCESS_KEY, s.TASKCLUSTER_AWS_SECRET_KEY
+
+
+account_id, access_key, secret_key = get_aws_creds()

--- a/ci/rollback.py
+++ b/ci/rollback.py
@@ -16,18 +16,43 @@ def get_aws_creds():
         config = ConfigParser()
         config.read(credentials_config)
         return config.get('occ-taskcluster', 'aws_account_id'), config.get('occ-taskcluster', 'aws_access_key_id'), config.get('occ-taskcluster', 'aws_secret_access_key')
-
     url = 'http://taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/OpenCloudConfig:updateworkertype'
-    s = requests.get(url).json().secret
-    return s.aws_tc_account_id, s.TASKCLUSTER_AWS_ACCESS_KEY, s.TASKCLUSTER_AWS_SECRET_KEY
+    secret = requests.get(url).json().secret
+    return secret.aws_tc_account_id, secret.TASKCLUSTER_AWS_ACCESS_KEY, secret.TASKCLUSTER_AWS_SECRET_KEY
 
 
-aws_account_id, aws_access_key_id, aws_secret_access_key = get_aws_creds()
-boto3.setup_default_session(
-    aws_access_key_id=aws_access_key_id,
-    aws_secret_access_key=aws_secret_access_key)
-ec2 = boto3.client('ec2')
-response = ec2.describe_images(
-    Owners=[aws_account_id],
-    Filters=[{'Name':'name', 'Values':['gecko-*-b-win* version *', 'gecko-t-win* version *']}])
-print json.dumps(response, indent=2, sort_keys=True)
+def mutate(image, region_name):
+    """
+    retrieves the properties of interest from the ec2 describe_image json
+    """
+    name = image['Name'].split()
+    return {
+        'CreationDate': image['CreationDate'],
+        'ImageId': image['ImageId'],
+        'WorkerType': name[0],
+        'GitSha': name[-1],
+        'Region': region_name
+    }
+
+
+def get_ami_list(
+    regions=['eu-central-1', 'us-west-1', 'us-west-2', 'us-east-1', 'us-east-2'],
+    name_patterns=['gecko-*-b-win* version *', 'gecko-t-win* version *']):
+    """
+    retrieves a list of amis in the specified regions and matching the specified name patterns
+    """
+    aws_account_id, aws_access_key_id, aws_secret_access_key = get_aws_creds()
+    boto3.setup_default_session(
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key)
+    images = []
+    for region_name in regions:
+        ec2 = boto3.client('ec2', region_name=region_name)
+        response = ec2.describe_images(
+            Owners=[aws_account_id],
+            Filters=[{'Name': 'name', 'Values': name_patterns}])
+        images += [mutate(image, region_name) for image in response['Images']]
+    return images
+
+
+print json.dumps(get_ami_list(), indent=2, sort_keys=True)


### PR DESCRIPTION
- parse commit messages that contain rollback syntax in the format:
`rollback: worker-type git-sha`
eg:
`rollback: gecko-t-win7-32-beta 7480b11`
- query ec2 for amis associated with the specified worker type and git sha.
- query ec2 for security groups in the regions of the associated amis.
- update aws provisioner config for the specified worker type with the region specific ami ids and security groups resulting in an effective and immediate rollback
- when no rollback syntax is detected, create a list of available rollback configurations in the task log