### PR TITLE
 Bug 1464343 - use hardened sshd config

### DIFF
--- a/userdata/Configuration/ssh/sshd_config
+++ b/userdata/Configuration/ssh/sshd_config
@@ -1,0 +1,8 @@
+# Use default settings with the exception of the following options derived from:
+# https://infosec.mozilla.org/guidelines/openssh.html#intermediate-openssh-53
+
+LogLevel VERBOSE
+PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+PasswordAuthentication no
+Subsystem sftp sftp-server.exe -f AUTHPRIV -l INFO

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1412,6 +1412,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1420,8 +1433,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1412,6 +1412,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1420,8 +1433,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1412,6 +1412,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1420,8 +1433,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1290,6 +1290,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1298,8 +1311,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1290,6 +1290,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1298,8 +1311,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1342,6 +1342,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1350,8 +1363,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1342,6 +1342,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1350,8 +1363,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1397,6 +1397,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1405,8 +1418,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1290,6 +1290,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1298,8 +1311,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -1301,6 +1301,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1309,8 +1322,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -1301,6 +1301,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1309,8 +1322,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win7-32-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu-b.json
@@ -1301,6 +1301,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1309,8 +1322,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -1301,6 +1301,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1309,8 +1322,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -1330,6 +1330,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1338,8 +1351,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -1301,6 +1301,19 @@
       ]
     },
     {
+      "ComponentName": "sshd_config",
+      "ComponentType": "ChecksumFileDownload",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1464343",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/ssh/sshd_config",
+      "Target": "C:\\ProgramData\\ssh\\sshd_config",
+      "DependsOn": [
+        {
+          "ComponentType": "CommandRun",
+          "ComponentName": "InstallOpenSSH"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_sshd",
       "ComponentType": "ServiceControl",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",
@@ -1309,8 +1322,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "CommandRun",
-          "ComponentName": "InstallOpenSSH"
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "sshd_config"
         }
       ]
     },


### PR DESCRIPTION
modify sshd config implementing:
- disable password authentication (accept only ssh key authentication)
- log key fingerprint of successful connections
- other recommendations from https://infosec.mozilla.org/guidelines/openssh.html#intermediate-openssh-53