### PR TITLE
Bug 1465113 rollback

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1000,9 +1000,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "c0d2a658f5fb6e6e99fa84b64a91b34dd521cacdf7795f81061b170e345658e3c817a25e6f46cd06d072d33b25cc1c364b0aeccb5cffd36479aeef347f251266"
+      "sha512": "0e9a03b5717e51b720e44b97368b50f3ad511becb6717504bd33eda16bdededd79c7444c7cb2f74857c85629abcbc189f72b3745a1efc9fa63f71b4e4da459c7"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1123,7 +1123,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1000,9 +1000,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "c0d2a658f5fb6e6e99fa84b64a91b34dd521cacdf7795f81061b170e345658e3c817a25e6f46cd06d072d33b25cc1c364b0aeccb5cffd36479aeef347f251266"
+      "sha512": "0e9a03b5717e51b720e44b97368b50f3ad511becb6717504bd33eda16bdededd79c7444c7cb2f74857c85629abcbc189f72b3745a1efc9fa63f71b4e4da459c7"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1123,7 +1123,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1000,9 +1000,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "c0d2a658f5fb6e6e99fa84b64a91b34dd521cacdf7795f81061b170e345658e3c817a25e6f46cd06d072d33b25cc1c364b0aeccb5cffd36479aeef347f251266"
+      "sha512": "0e9a03b5717e51b720e44b97368b50f3ad511becb6717504bd33eda16bdededd79c7444c7cb2f74857c85629abcbc189f72b3745a1efc9fa63f71b4e4da459c7"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1123,7 +1123,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -408,9 +408,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "c0d2a658f5fb6e6e99fa84b64a91b34dd521cacdf7795f81061b170e345658e3c817a25e6f46cd06d072d33b25cc1c364b0aeccb5cffd36479aeef347f251266"
+      "sha512": "0e9a03b5717e51b720e44b97368b50f3ad511becb6717504bd33eda16bdededd79c7444c7cb2f74857c85629abcbc189f72b3745a1efc9fa63f71b4e4da459c7"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -531,7 +531,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -408,9 +408,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "c0d2a658f5fb6e6e99fa84b64a91b34dd521cacdf7795f81061b170e345658e3c817a25e6f46cd06d072d33b25cc1c364b0aeccb5cffd36479aeef347f251266"
+      "sha512": "0e9a03b5717e51b720e44b97368b50f3ad511becb6717504bd33eda16bdededd79c7444c7cb2f74857c85629abcbc189f72b3745a1efc9fa63f71b4e4da459c7"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -531,7 +531,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -481,9 +481,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "2857f39f94e423919241698b270756cfc93d7d4bac6b5376c56d6b5f3b47ad674276bc0efcf4da8b195f2fa24859148c192dc815a47a28260f5eab80d38a549a"
+      "sha512": "e345c376cd5e6cf2635a4b086a1e9a0dc234d990ff14f35503bb92504d641265da8d9a466f8c47cac06f7279d02f1745040e13c4bcd90bf06710ac83f3d9f9d1"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -604,7 +604,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -481,9 +481,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.3/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v10.8.1/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "2857f39f94e423919241698b270756cfc93d7d4bac6b5376c56d6b5f3b47ad674276bc0efcf4da8b195f2fa24859148c192dc815a47a28260f5eab80d38a549a"
+      "sha512": "e345c376cd5e6cf2635a4b086a1e9a0dc234d990ff14f35503bb92504d641265da8d9a466f8c47cac06f7279d02f1745040e13c4bcd90bf06710ac83f3d9f9d1"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -604,7 +604,7 @@
             "Arguments": [
               "--version"
             ],
-            "Match": "generic-worker 10.8.3"
+            "Match": "generic-worker 10.8.1"
           }
         ]
       }


### PR DESCRIPTION
This reverts the changes for [bug 1465113](https://bugzilla.mozilla.org/show_bug.cgi?id=1465113) since it reintroduced a [regression](https://sentry.prod.mozaws.net/operations/generic-worker/issues/3248027/) that had been fixed in generic-worker 10.8.1.

