### PR TITLE
Bug 1451837 - run dism command to clean up

### DIFF
--- a/userdata/Configuration/GenericWorker/run-hw-generic-worker-8-and-reboot.bat
+++ b/userdata/Configuration/GenericWorker/run-hw-generic-worker-8-and-reboot.bat
@@ -22,6 +22,7 @@ FOR /f "usebackq delims== tokens=2" %%x IN (`wmic logicaldisk where "DeviceID='C
 SET FreeSpace=!FreeSpaceBig:~0,-7!
 IF %FreeSpace% GTR 25240 echo %FreeSpace% MB available disk space >> C:\generic-worker\generic-worker.log
 IF %FreeSpace% LSS 25240 echo Disk space ABNORMALLY low  %FreeSpace% MB available >> C:\generic-worker\generic-worker.log
+IF %FreeSpace% LSS 25240 Dism.exe /online /Cleanup-Image /StartComponentCleanup >> C:\generic-worker\generic-worker.log
 IF %FreeSpace% LSS 15240 echo ALERT disk space is low %FreeSpace% MB available >> C:\generic-worker\generic-worker.log
 ENDLOCAL
 


### PR DESCRIPTION
After disk space less that 25 GB run a dism command. This command will clean up C:\Windows\WinSxS among other items. I putting this outside of the cleanup portion, so it will not run on every time generic worker exits. When this was the case we saw some odd behavior with this command.