### PR TITLE
Bug 1469351 - Vendor latest robustcheckout

### DIFF
--- a/userdata/Configuration/FirefoxBuildResources/robustcheckout.py
+++ b/userdata/Configuration/FirefoxBuildResources/robustcheckout.py
@@ -33,6 +33,7 @@ from mercurial import (
     cmdutil,
     hg,
     match as matchmod,
+    phases,
     registrar,
     scmutil,
     util,
@@ -41,8 +42,12 @@ from mercurial import (
 # TRACKING hg43
 try:
     from mercurial import configitems
+    configitems.dynamicdefault
 except ImportError:
     configitems = None
+
+# Causes worker to purge caches on process exit and for task to retry.
+EXIT_PURGE_CACHE = 72
 
 testedwith = '3.7 3.8 3.9 4.0 4.1 4.2 4.3 4.4 4.5'
 minimumhgversion = '3.7'
@@ -694,6 +699,30 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
             raise error.Abort('error updating')
 
     ui.write('updated to %s\n' % checkoutrevision)
+
+    # HACK workaround https://bz.mercurial-scm.org/show_bug.cgi?id=5905
+    # and https://bugzilla.mozilla.org/show_bug.cgi?id=1462323.
+    #
+    # hg.mozilla.org's load balancer may route requests to different origin
+    # servers, thus exposing inconsistent state of repositories to the peer.
+    # This confuses Mercurial into promoting draft changesets to public. And
+    # this confuses various processes that rely on changeset phases being
+    # accurate.
+    #
+    # Our hack is to verify that changesets on non-publishing repositories are
+    # draft and to nuke the repo if they are wrong. We only apply this hack to
+    # the Try repo because it is the only repo where we can safely assume
+    # that the requested revision must be draft. This is because CI is triggered
+    # from special changesets that when pushed are always heads. And since the
+    # repo is non-publishing, these changesets should never be public.
+    if url in ('https://hg.mozilla.org/try',
+               'https://hg.mozilla.org/try-comm-central'):
+        if repo[checkoutrevision].phase() == phases.public:
+            ui.write(_('error: phase of revision is public; this is likely '
+                       'a manifestation of bug 1462323; the task will be '
+                       'retried\n'))
+            return EXIT_PURGE_CACHE
+
     return None
 
 


### PR DESCRIPTION
From changeset bfbbe0cc67be26f55b70a0ac4cffb86861879985 from
version-control-tools.

This will cause tasks to exit with code 72 if the repo is in a bad state
due to bug 1462323.