### PR TITLE
Bug 1474159 - disable hg thread pool for closing file handles

### DIFF
--- a/userdata/Configuration/Mercurial/mercurial.ini
+++ b/userdata/Configuration/Mercurial/mercurial.ini
@@ -26,3 +26,6 @@ ftp-ssl.mozilla.org:fingerprints = sha1:9d:8e:3e:7c:4a:33:6f:53:c6:64:a8:48:d3:e
 traceback=true
 username=Mozilla Release Engineering <release@mozilla.com>
 clonebundleprefers=VERSION=packed1
+
+[worker]
+backgroundclose=false

--- a/userdata/Configuration/Mercurial/mercurial.ini
+++ b/userdata/Configuration/Mercurial/mercurial.ini
@@ -28,4 +28,4 @@ username=Mozilla Release Engineering <release@mozilla.com>
 clonebundleprefers=VERSION=packed1
 
 [worker]
-backgroundclose=false
+enabled=false


### PR DESCRIPTION
this setting disables the hg thread pool for closing file handles which is a feature designed to optimise hg  when windows defender is running. in the case of our 2012 instances, defender is not installed and on win 7 and 10, defender is explicitly disabled. the setting should remove the overhead of this feature and make hg operations faster.