### PR TITLE
 Bug 1475764 - match log aggregator domain to instance domain 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,6 +345,19 @@ Instance configuration is defined in json format and currently includes implemen
     "Action": "Allow"
   }
   ```
+- **[ReplaceInFile](https://github.com/search?q=ReplaceInFile+language%3Apowershell+repo%3Amozilla-releng%2FOpenCloudConfig&type=Code)**:
+  Replace text in a file (optionally using a powershell expression or variable)
+
+  *example*:
+  ```
+  {
+    "ComponentName": "SetNxlogAggregator",
+    "ComponentType": "ReplaceInFile",
+    "Path": "C:\\Program Files (x86)\\nxlog\\conf\\nxlog.conf",
+    "Match": "DatacenterToken",
+    "Replace": "$env:datacenter"
+  }
+  ```
 
 # OpenCloudConfig CI
 

--- a/userdata/Manifest/gecko-t-win10-64-hw-GW10.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw-GW10.json
@@ -42,6 +42,19 @@
       ]
     },
     {
+      "ComponentName": "SetLogAggregator",
+      "ComponentType": "ReplaceInFile",
+      "Path": "C:\\Program Files (x86)\\nxlog\\conf\\nxlog.conf",
+      "Match": "mdc1.mozilla.com",
+      "Replace": "((Get-ItemProperty 'HKLM:SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters').'NV Domain').Replace('wintest.releng.', '')",
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "NxLogPaperTrailConfiguration"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_nxlog",
       "ComponentType": "ServiceControl",
       "Comment": "Maintenance Toolchain - not essential for building firefox",
@@ -50,8 +63,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "ChecksumFileDownload",
-          "ComponentName": "NxLogPaperTrailConfiguration"
+          "ComponentType": "ReplaceInFile",
+          "ComponentName": "SetLogAggregator"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -42,6 +42,19 @@
       ]
     },
     {
+      "ComponentName": "SetLogAggregator",
+      "ComponentType": "ReplaceInFile",
+      "Path": "C:\\Program Files (x86)\\nxlog\\conf\\nxlog.conf",
+      "Match": "mdc1.mozilla.com",
+      "Replace": "((Get-ItemProperty 'HKLM:SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters').'NV Domain').Replace('wintest.releng.', '')",
+      "DependsOn": [
+        {
+          "ComponentType": "ChecksumFileDownload",
+          "ComponentName": "NxLogPaperTrailConfiguration"
+        }
+      ]
+    },
+    {
       "ComponentName": "Start_nxlog",
       "ComponentType": "ServiceControl",
       "Comment": "Maintenance Toolchain - not essential for building firefox",
@@ -50,8 +63,8 @@
       "State": "Running",
       "DependsOn": [
         {
-          "ComponentType": "ChecksumFileDownload",
-          "ComponentName": "NxLogPaperTrailConfiguration"
+          "ComponentType": "ReplaceInFile",
+          "ComponentName": "SetLogAggregator"
         }
       ]
     },

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -662,7 +662,7 @@ Configuration xDynamicConfig {
           DependsOn = @( @($item.DependsOn) | ? { (($_) -and ($_.ComponentType)) } | % { ('[{0}]{1}_{2}' -f $componentMap.Item($_.ComponentType), $_.ComponentType, $_.ComponentName) } )
           GetScript = "@{ ReplaceInFile = $item.ComponentName }"
           SetScript = {
-            (Get-Content $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File $using:item.Path
+            (Get-Content $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File $using:item.Path -Encoding 'UTF8'
           }
           TestScript = { return $false }
         }

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -150,7 +150,8 @@ Configuration xDynamicConfig {
     'RegistryKeySet' = 'Registry';
     'RegistryValueSet' = 'Registry';
     'DisableIndexing' = 'Script';
-    'FirewallRule' = 'Script'
+    'FirewallRule' = 'Script';
+    'ReplaceInFile' = 'Script'
   }
   Log Manifest {
     Message = ('Manifest: {0}' -f $manifest)
@@ -653,6 +654,20 @@ Configuration xDynamicConfig {
         }
         Log ('Log_FirewallRule_{0}' -f $item.ComponentName) {
           DependsOn = ('[Script]FirewallRule_{0}' -f $item.ComponentName)
+          Message = ('{0}: {1}, completed' -f $item.ComponentType, $item.ComponentName)
+        }
+      }
+      'ReplaceInFile' {
+        Script ('ReplaceInFile_{0}' -f $item.ComponentName) {
+          DependsOn = @( @($item.DependsOn) | ? { (($_) -and ($_.ComponentType)) } | % { ('[{0}]{1}_{2}' -f $componentMap.Item($_.ComponentType), $_.ComponentType, $_.ComponentName) } )
+          GetScript = "@{ ReplaceInFile = $item.ComponentName }"
+          SetScript = {
+            (Get-Content $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File $using:item.Path
+          }
+          TestScript = { return $false }
+        }
+        Log ('Log_ReplaceInFile__{0}' -f $item.ComponentName) {
+          DependsOn = ('[Script]ReplaceInFile__{0}' -f $item.ComponentName)
           Message = ('{0}: {1}, completed' -f $item.ComponentType, $item.ComponentName)
         }
       }

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -662,7 +662,7 @@ Configuration xDynamicConfig {
           DependsOn = @( @($item.DependsOn) | ? { (($_) -and ($_.ComponentType)) } | % { ('[{0}]{1}_{2}' -f $componentMap.Item($_.ComponentType), $_.ComponentType, $_.ComponentName) } )
           GetScript = "@{ ReplaceInFile = $item.ComponentName }"
           SetScript = {
-            (Get-Content $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File $using:item.Path -Encoding 'UTF8'
+            (Get-Content $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File -FilePath $using:item.Path -Encoding 'UTF8'
           }
           TestScript = { return $false }
         }

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -662,7 +662,8 @@ Configuration xDynamicConfig {
           DependsOn = @( @($item.DependsOn) | ? { (($_) -and ($_.ComponentType)) } | % { ('[{0}]{1}_{2}' -f $componentMap.Item($_.ComponentType), $_.ComponentType, $_.ComponentName) } )
           GetScript = "@{ ReplaceInFile = $item.ComponentName }"
           SetScript = {
-            (Get-Content -Path $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File -FilePath $using:item.Path -Encoding 'UTF8'
+            $content = ((Get-Content -Path $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) })
+            [System.IO.File]::WriteAllLines($using:item.Path, $content, (New-Object System.Text.UTF8Encoding $false))
           }
           TestScript = { return $false }
         }

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -666,8 +666,8 @@ Configuration xDynamicConfig {
           }
           TestScript = { return $false }
         }
-        Log ('Log_ReplaceInFile__{0}' -f $item.ComponentName) {
-          DependsOn = ('[Script]ReplaceInFile__{0}' -f $item.ComponentName)
+        Log ('Log_ReplaceInFile_{0}' -f $item.ComponentName) {
+          DependsOn = ('[Script]ReplaceInFile_{0}' -f $item.ComponentName)
           Message = ('{0}: {1}, completed' -f $item.ComponentType, $item.ComponentName)
         }
       }

--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -662,7 +662,7 @@ Configuration xDynamicConfig {
           DependsOn = @( @($item.DependsOn) | ? { (($_) -and ($_.ComponentType)) } | % { ('[{0}]{1}_{2}' -f $componentMap.Item($_.ComponentType), $_.ComponentType, $_.ComponentName) } )
           GetScript = "@{ ReplaceInFile = $item.ComponentName }"
           SetScript = {
-            (Get-Content $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File -FilePath $using:item.Path -Encoding 'UTF8'
+            (Get-Content -Path $using:item.Path) | Foreach-Object { $_ -replace $using:item.Match, (Invoke-Expression -Command $using:item.Replace) } | Out-File -FilePath $using:item.Path -Encoding 'UTF8'
           }
           TestScript = { return $false }
         }


### PR DESCRIPTION
- support is added here for replacing text in files with either a string or the output of a powershell expression.
- the win 10 hardware manifests are updated to use the text replacement component to match the log aggregator domain with the instance domain
  - the instance domain is taken from the registry
  - the "wintest.releng." prefix is removed, if present
  - the string "mdc1.mozilla.com" in the nxlog config is replaced with the instance domain computed as described above