### PR TITLE
Bug 1480112 - handle dsc run failures

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1452,6 +1452,20 @@
           "ComponentName": "InstallOpenSSH"
         }
       ]
+    },
+    {
+      "ComponentName": "IntentionalBustage",
+      "ComponentType": "CommandRun",
+      "Comment": "This component will always fail to validate and is used to simulate bustage.",
+      "Command": "echo",
+      "Arguments": [
+        "bustage"
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\path\\does\\not\\exist"
+        ]
+      }
     }
   ],
   "ProvisionerConfiguration": {


### PR DESCRIPTION
if a dsc run fails (indicated by the presence of "failed to execute Set-TargetResource" in the dsc transcript), this logic will cause occ to sleep until the taskcluster github task times out causing a deployment failure and preventing an incomplete ami from being deployed.