### PR TITLE
Bug 1439588 - make xperf.exe available in PATH on gecko-t-win7-32

### DIFF
--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -466,7 +466,8 @@
         "C:\\mozilla-build\\python\\Scripts",
         "C:\\mozilla-build\\upx391w",
         "C:\\mozilla-build\\wget",
-        "C:\\mozilla-build\\yasm"
+        "C:\\mozilla-build\\yasm",
+        "C:\\Program Files\\Microsoft Windows Performance Toolkit"
       ],
       "Target": "Machine"
     },


### PR DESCRIPTION
Hi Rob, I need to check with @jmaher first if this is ok with him before we land it.

I wasn't sure which other worker types might have the performance tools also installed - do you know which step installs it, so I can see which other worker types also have it?

Thanks.