### PR TITLE
Bug 1480368 - validate sha512 hash on file download

### DIFF
--- a/userdata/xDynamicConfig.ps1
+++ b/userdata/xDynamicConfig.ps1
@@ -243,7 +243,7 @@ Configuration xDynamicConfig {
             Unblock-File -Path $using:item.Target
           }
           TestScript = {
-            return Log-Validation (Validate-PathsExistOrNotRequested -items @($using:item.Target) -verbose) -verbose
+            return ((Log-Validation (Validate-PathsExistOrNotRequested -items @($using:item.Target) -verbose) -verbose) -and ((-not ($using:item.sha512)) -or ((Get-FileHash -Path $using:item.Target -Algorithm 'SHA512').Hash -eq $using:item.sha512)))
           }
         }
         Log ('Log_FileDownload_{0}' -f $item.ComponentName) {


### PR DESCRIPTION
if a sha512 was specified for tooltool download of a FileDownload component, validate the downloaded file has a sha512 hash matching the one in the manifest and use the result for the dsc validation of component run success