### PR TITLE
Maintain system

### DIFF
--- a/userdata/Configuration/nxlog/gecko-3-b-win2012.conf
+++ b/userdata/Configuration/nxlog/gecko-3-b-win2012.conf
@@ -16,7 +16,7 @@ LogFile   %ROOT%\data\nxlog.log
   Query <QueryList>\
           <Query Id="0">\
             <Select Path="Microsoft-Windows-DSC/Operational">*</Select>\
-            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner']]]</Select>\
+            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner'] or Provider[@Name='MaintainSystem']]]</Select>\
             <Select Path="Application">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="Security">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="System">*[System[Level=1 or Level=2 or Level=3 or EventID=1074]]</Select>\

--- a/userdata/Configuration/nxlog/hw-win10.conf
+++ b/userdata/Configuration/nxlog/hw-win10.conf
@@ -17,7 +17,7 @@ LogFile   %ROOT%\data\nxlog.log
   Query <QueryList>\
           <Query Id="0">\
             <Select Path="Microsoft-Windows-DSC/Operational">*</Select>\
-            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig']]]</Select>\
+            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='MaintainSystem']]]</Select>\
             <Select Path="Application">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="Security">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="System">*[System[Level=1 or Level=2 or Level=3 or EventID=1074]]</Select>\

--- a/userdata/Configuration/nxlog/hw-win7.conf
+++ b/userdata/Configuration/nxlog/hw-win7.conf
@@ -17,7 +17,7 @@ LogLevel DEBUG
   Query <QueryList>\
           <Query Id="0">\
             <Select Path="Microsoft-Windows-DSC/Operational">*</Select>\
-            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner']]]</Select>\
+            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner'] or Provider[@Name='MaintainSystem']]]</Select>\
             <Select Path="Application">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="Security">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="System">*[System[Level=1 or Level=2 or Level=3 or EventID=1074]]</Select>\

--- a/userdata/Configuration/nxlog/win10.conf
+++ b/userdata/Configuration/nxlog/win10.conf
@@ -16,7 +16,7 @@ LogFile   %ROOT%\data\nxlog.log
   Query <QueryList>\
           <Query Id="0">\
             <Select Path="Microsoft-Windows-DSC/Operational">*</Select>\
-            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner']]]</Select>\
+            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner'] or Provider[@Name='MaintainSystem']]]</Select>\
             <Select Path="Application">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="Security">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="System">*[System[Level=1 or Level=2 or Level=3 or EventID=1074]]</Select>\

--- a/userdata/Configuration/nxlog/win2012.conf
+++ b/userdata/Configuration/nxlog/win2012.conf
@@ -16,7 +16,7 @@ LogFile   %ROOT%\data\nxlog.log
   Query <QueryList>\
           <Query Id="0">\
             <Select Path="Microsoft-Windows-DSC/Operational">*</Select>\
-            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner']]]</Select>\
+            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner'] or Provider[@Name='MaintainSystem']]]</Select>\
             <Select Path="Application">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="Security">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="System">*[System[Level=1 or Level=2 or Level=3 or EventID=1074]]</Select>\

--- a/userdata/Configuration/nxlog/win7.conf
+++ b/userdata/Configuration/nxlog/win7.conf
@@ -16,7 +16,7 @@ LogFile   %ROOT%\data\nxlog.log
   Query <QueryList>\
           <Query Id="0">\
             <Select Path="Microsoft-Windows-DSC/Operational">*</Select>\
-            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner']]]</Select>\
+            <Select Path="Application">*[System[Provider[@Name='OpenCloudConfig'] or Provider[@Name='HaltOnIdle'] or Provider[@Name='PrepLoaner'] or Provider[@Name='MaintainSystem']]]</Select>\
             <Select Path="Application">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="Security">*[System[Level=1 or Level=2 or Level=3]]</Select>\
             <Select Path="System">*[System[Level=1 or Level=2 or Level=3 or EventID=1074]]</Select>\

--- a/userdata/MaintainSystem.ps1
+++ b/userdata/MaintainSystem.ps1
@@ -1,0 +1,75 @@
+function Write-Log {
+  param (
+    [string] $message,
+    [string] $severity = 'INFO',
+    [string] $source = 'MaintainSystem',
+    [string] $logName = 'Application'
+  )
+  if (!([Diagnostics.EventLog]::Exists($logName)) -or !([Diagnostics.EventLog]::SourceExists($source))) {
+    New-EventLog -LogName $logName -Source $source
+  }
+  switch ($severity) {
+    'DEBUG' {
+      $entryType = 'SuccessAudit'
+      $eventId = 2
+      break
+    }
+    'WARN' {
+      $entryType = 'Warning'
+      $eventId = 3
+      break
+    }
+    'ERROR' {
+      $entryType = 'Error'
+      $eventId = 4
+      break
+    }
+    default {
+      $entryType = 'Information'
+      $eventId = 1
+      break
+    }
+  }
+  Write-EventLog -LogName $logName -Source $source -EntryType $entryType -Category 0 -EventID $eventId -Message $message
+  if ([Environment]::UserInteractive) {
+    $fc = @{ 'Information' = 'White'; 'Error' = 'Red'; 'Warning' = 'DarkYellow'; 'SuccessAudit' = 'DarkGray' }[$entryType]
+    Write-Host -object $message -ForegroundColor $fc
+  }
+}
+
+function Remove-OldTaskDirectories {
+  param (
+    [string[]] $targets = @('Z:\task_*', 'C:\Users\task_*')
+  )
+  begin {
+    Write-Log -message ('{0} :: begin' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+  }
+  process {
+    foreach ($target in ($targets | ? { (Test-Path -Path ('{0}:\' -f $_[0]) -ErrorAction SilentlyContinue) })) {
+      $all_task_paths = @(Get-ChildItem -Path $target | Sort-Object -Property { $_.LastWriteTime })
+      if ($all_task_paths.length -gt 1) {
+        Write-Log -message ('{0} task directories detected matching pattern: {1}' -f $all_task_paths.length, $target) -severity 'INFO'
+        $old_task_paths = $all_task_paths[0..($all_task_paths.Length-2)]
+        foreach ($old_task_path in $old_task_paths) {
+          try {
+            & takeown.exe @('/a', '/f', $old_task_path, '/r', '/d', 'Y')
+            & icacls.exe @($old_task_path, '/grant', 'Administrators:F', '/t')
+            Remove-Item -Path $old_task_path -Force -Recurse
+            Write-Log -message ('removed task directory: {0}, with last write time: {1}' -f $old_task_path.FullName, $old_task_path.LastWriteTime) -severity 'INFO'
+          } catch {
+            Write-Log -message ('failed to remove task directory: {0}, with last write time: {1}. {2}' -f $old_task_path.FullName, $old_task_path.LastWriteTime, $_.Exception.Message) -severity 'ERROR'
+          }
+        }
+      } elseif ($all_task_paths.length -eq 1) {
+        Write-Log -message ('a single task directory was detected at: {0}, with last write time: {1}' -f $all_task_paths[0].FullName, $all_task_paths[0].LastWriteTime) -severity 'DEBUG'
+      } else {
+        Write-Log -message ('no task directories detected matching pattern: {0}' -f $target) -severity 'DEBUG'
+      }
+    }
+  }
+  end {
+    Write-Log -message ('{0} :: end' -f $($MyInvocation.MyCommand.Name)) -severity 'DEBUG'
+  }
+}
+
+Remove-OldTaskDirectories

--- a/userdata/rundsc.ps1
+++ b/userdata/rundsc.ps1
@@ -1190,6 +1190,8 @@ if ($rebootReasons.length) {
   }
   # create a scheduled task to run PrepLoaner every minute (only preps loaner if appropriate flags exist. flags are created by user tasks)
   Create-ScheduledPowershellTask -taskName 'PrepLoaner' -scriptUrl ('https://raw.githubusercontent.com/{0}/OpenCloudConfig/master/userdata/PrepLoaner.ps1?{1}' -f $SourceRepo, [Guid]::NewGuid()) -scriptPath 'C:\dsc\PrepLoaner.ps1' -sc 'minute' -mo '1'
+  # create a scheduled task to run system maintenance every minute
+  Create-ScheduledPowershellTask -taskName 'MaintainSystem' -scriptUrl ('https://raw.githubusercontent.com/{0}/OpenCloudConfig/master/userdata/MaintainSystem.ps1?{1}' -f $SourceRepo, [Guid]::NewGuid()) -scriptPath 'C:\dsc\MaintainSystem.ps1' -sc 'minute' -mo '1'
   if ($locationType -eq 'DataCenter') {
     $isWorker = $true
     $runDscOnWorker = $true


### PR DESCRIPTION
this pr creates a new scheduled task called MaintainSystem which runs each minute on both hardware and ec2 workers. the task runs a new script called MaintainSystem.ps1 which currently has a single maintenance function which looks for task folders in the usual locations

- C:\Users\task_*
- Z:\task_*

if any task folders are found, all except the most recently created task folder are deleted by

- first taking ownership of the task folder and files and folders within it
- then adding an acl giving the adminitrators group full access to the task folder path and files and folders within it
- and finally deleting the task folder path and files and folders within it

additionally log events created by the scheduled task are forwarded to papertrail for debugging purposes