### PR TITLE
Bug 1490703 - upgrade hg from 4.5.3 to 4.7.1

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -521,11 +521,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -521,11 +521,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -521,11 +521,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -275,11 +275,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -275,11 +275,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-hw-GW10.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw-GW10.json
@@ -526,11 +526,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -526,11 +526,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -275,11 +275,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x64.msi",
-      "Name": "Mercurial 4.5.3 (x64)",
-      "ProductId": "3F975FA0-6C28-4A37-882B-2AB806D67736",
-      "sha512": "3b22fcf113fa227b2fa92b16b53c8753949df8341bacde340406e225abfd0b4241a1e75aed3c2e66fffcc2244fd392e99f35508e1921f7d09306f6ce68e08c1f"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x64.msi",
+      "Name": "Mercurial 4.7.1 (x64)",
+      "ProductId": "68FA175A-0F28-49AF-9E65-30CE6B60AE1C",
+      "sha512": "b3c957860855840c54d7407e13eb129c408c6ee9d5bf6547b5fb598321bc016c53d991cccbc5a63a78963057738aef43efd1da358b2ec41f66389d6be2fdc1cf"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -379,11 +379,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x86.msi",
-      "Name": "Mercurial 4.5.3 (x86)",
-      "ProductId": "8BC19702-0921-45F5-9B76-7BE3C2AE2E36",
-      "sha512": "1c2ca9c5238fa7e9848acee86b2b195278f51b7f531f69a9ade9b8422947ba4fc7caf02d21fb3c8e659eb7170f4101db5353f9421357f712711a24c755126fb7"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x86.msi",
+      "Name": "Mercurial 4.7.1 (x86)",
+      "ProductId": "2190A397-656F-4D0B-AAF6-1BBE030F7BE2",
+      "sha512": "e255574fa70ac820ccd9046387b203262ed4bde07588359ae94c94cb13684f55c835e8c55ef6c1c2594a3769148057498a281b2c4753539a7a0ea12f36b999da"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -379,11 +379,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x86.msi",
-      "Name": "Mercurial 4.5.3 (x86)",
-      "ProductId": "8BC19702-0921-45F5-9B76-7BE3C2AE2E36",
-      "sha512": "1c2ca9c5238fa7e9848acee86b2b195278f51b7f531f69a9ade9b8422947ba4fc7caf02d21fb3c8e659eb7170f4101db5353f9421357f712711a24c755126fb7"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x86.msi",
+      "Name": "Mercurial 4.7.1 (x86)",
+      "ProductId": "2190A397-656F-4D0B-AAF6-1BBE030F7BE2",
+      "sha512": "e255574fa70ac820ccd9046387b203262ed4bde07588359ae94c94cb13684f55c835e8c55ef6c1c2594a3769148057498a281b2c4753539a7a0ea12f36b999da"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -581,11 +581,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x86.msi",
-      "Name": "Mercurial 4.5.3 (x86)",
-      "ProductId": "8BC19702-0921-45F5-9B76-7BE3C2AE2E36",
-      "sha512": "1c2ca9c5238fa7e9848acee86b2b195278f51b7f531f69a9ade9b8422947ba4fc7caf02d21fb3c8e659eb7170f4101db5353f9421357f712711a24c755126fb7"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x86.msi",
+      "Name": "Mercurial 4.7.1 (x86)",
+      "ProductId": "2190A397-656F-4D0B-AAF6-1BBE030F7BE2",
+      "sha512": "e255574fa70ac820ccd9046387b203262ed4bde07588359ae94c94cb13684f55c835e8c55ef6c1c2594a3769148057498a281b2c4753539a7a0ea12f36b999da"
     },
     {
       "ComponentName": "MercurialConfig",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -379,11 +379,11 @@
     {
       "ComponentName": "Mercurial",
       "ComponentType": "MsiInstall",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1456395",
-      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.5.3-x86.msi",
-      "Name": "Mercurial 4.5.3 (x86)",
-      "ProductId": "8BC19702-0921-45F5-9B76-7BE3C2AE2E36",
-      "sha512": "1c2ca9c5238fa7e9848acee86b2b195278f51b7f531f69a9ade9b8422947ba4fc7caf02d21fb3c8e659eb7170f4101db5353f9421357f712711a24c755126fb7"
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1490703",
+      "Url": "https://www.mercurial-scm.org/release/windows/mercurial-4.7.1-x86.msi",
+      "Name": "Mercurial 4.7.1 (x86)",
+      "ProductId": "2190A397-656F-4D0B-AAF6-1BBE030F7BE2",
+      "sha512": "e255574fa70ac820ccd9046387b203262ed4bde07588359ae94c94cb13684f55c835e8c55ef6c1c2594a3769148057498a281b2c4753539a7a0ea12f36b999da"
     },
     {
       "ComponentName": "MercurialConfig",


### PR DESCRIPTION
this was deployed to beta workers earlier and tested here:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=d339170