### PR TITLE
Bug 1493744 - validate ssh key rsa bit lengths

### DIFF
--- a/ci/validate.sh
+++ b/ci/validate.sh
@@ -1,6 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
-for manifest in $(ls ./OpenCloudConfig/userdata/Manifest/gecko-*.json); do
-  echo "[opencloudconfig $(date --utc +"%F %T.%3NZ")] validating manifest ${manifest}"
-  jsonlint ${manifest}
-done
+./OpenCloudConfig/ci/validate_json_syntax.sh
+./OpenCloudConfig/ci/validate_rsa_keys.sh

--- a/ci/validate_json_syntax.sh
+++ b/ci/validate_json_syntax.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+for manifest in $(ls ./OpenCloudConfig/userdata/Manifest/gecko-*.json); do
+  echo "[opencloudconfig $(date --utc +"%F %T.%3NZ")] validating manifest ${manifest}"
+  jsonlint ${manifest}
+done

--- a/ci/validate_rsa_keys.sh
+++ b/ci/validate_rsa_keys.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+while read pub_key; do
+  rsa_bit_length=$(echo ${pub_key} | ssh-keygen -lf - | { read -a i; echo ${i[0]}; })
+  if [ ${rsa_bit_length} -lt 2048 ]; then
+    (>&2 echo "key (${pub_key##* }) with rsa bit length of ${rsa_bit_length} is rejected.")
+    exit 1
+  fi
+done < ./OpenCloudConfig/userdata/Configuration/ssh/authorized_keys
+exit

--- a/ci/validate_rsa_keys.sh
+++ b/ci/validate_rsa_keys.sh
@@ -2,7 +2,7 @@
 
 while read pub_key; do
   rsa_bit_length=$(echo ${pub_key} | ssh-keygen -lf - | { read -a i; echo ${i[0]}; })
-  if [ ${rsa_bit_length} -lt 2048 ]; then
+  if [ ${rsa_bit_length} -lt 4096 ]; then
     (>&2 echo "key (${pub_key##* }) with rsa bit length of ${rsa_bit_length} is rejected.")
     exit 1
   fi

--- a/userdata/Configuration/ssh/readme.md
+++ b/userdata/Configuration/ssh/readme.md
@@ -6,7 +6,7 @@ members of github org: mozilla-releng (https://github.com/orgs/mozilla-releng/pe
 
 keys should comply with guidelines at https://infosec.mozilla.org/guidelines/openssh#key-generation.
 
-keys with a bit length less than 2048 will be rejected. you can check the bit length of your ssh public key with a command similar to this:
+keys with a bit length less than 4096 will be rejected. you can check the bit length of your ssh public key with a command similar to this:
 
 ```
 ssh-keygen -lf ~/.ssh/id_rsa.pub


### PR DESCRIPTION
this pr adds a validation check on the contents of https://github.com/mozilla-releng/OpenCloudConfig/blob/master/userdata/Configuration/ssh/authorized_keys
specifically, it checks that all keys in this file have an rsa bit length of 2048 or higher.
if any key has an rsa bit length of less than 2048, the validation fails.