### PR TITLE
Bug 1479889 - remove drive format between tasks

### DIFF
--- a/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat
+++ b/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat
@@ -5,16 +5,12 @@ if exist C:\generic-worker\disable-desktop-interrupt.reg reg import C:\generic-w
 if exist C:\generic-worker\SetDefaultPrinter.ps1 powershell -NoLogo -file C:\generic-worker\SetDefaultPrinter.ps1 -WindowStyle hidden -NoProfile -ExecutionPolicy bypass
 
 :CheckForStateFlag
-if exist Z:\loan logoff /f /n
-if exist Z:\loan goto End
 if exist C:\dsc\task-claim-state.valid goto RunWorker
 ping -n 2 127.0.0.1 1>/nul
 goto CheckForStateFlag
 
 :RunWorker
 echo File C:\dsc\task-claim-state.valid found >> C:\generic-worker\generic-worker.log
-if exist Z:\loan logoff /f /n
-if exist Z:\loan goto End
 echo Deleting C:\dsc\task-claim-state.valid file >> C:\generic-worker\generic-worker.log
 del /Q /F C:\dsc\task-claim-state.valid >> C:\generic-worker\generic-worker.log 2>&1
 pushd %~dp0
@@ -23,7 +19,7 @@ set errorlevel=
 set gw_exit_code=%errorlevel%
 
 rem exit code 67 means generic worker has created a task user and wants to reboot into it
-if %gw_exit_code% equ 67 goto FormatAndReboot
+if %gw_exit_code% equ 67 goto Reboot
 
 rem exit code 68 means generic worker has reached it's idle timeout and the instance should be retired
 if %gw_exit_code% equ 68 goto RetireIdleInstance
@@ -35,10 +31,7 @@ goto End
 shutdown /s /t 10 /c "shutting down; max idle time reached" /d p:4:1
 goto End
 
-:FormatAndReboot
-if exist Z:\loan logoff /f /n
-if exist Z:\loan goto End
-format Z: /fs:ntfs /v:"task" /q /y
+:Reboot
 shutdown /r /t 0 /f /c "rebooting; generic worker task run completed" /d p:4:1
 
 :End

--- a/userdata/HaltOnIdle.ps1
+++ b/userdata/HaltOnIdle.ps1
@@ -89,10 +89,6 @@ function Is-RdpSessionActive {
   return (Is-ConditionTrue -proc 'remote desktop session' -predicate (@(Get-Process | ? { $_.ProcessName -eq 'rdpclip' }).length -gt 0) -activity 'active' -falseSeverity 'DEBUG')
 }
 
-function Is-DriveFormatInProgress {
-  return (Is-ConditionTrue -proc 'drive format' -predicate (@(Get-Process | ? { $_.ProcessName -eq 'format.com' }).length -gt 0) -activity 'in progress' -falseSeverity 'DEBUG')
-}
-
 function Is-Loaner {
   return ((Test-Path -Path 'Z:\loan-request.json' -ErrorAction SilentlyContinue) -or (Test-Path -Path 'HKLM:\SOFTWARE\OpenCloudConfig\Loan' -ErrorAction SilentlyContinue))
 }
@@ -131,11 +127,11 @@ if (-not (Is-Loaner)) {
     if (-not (Is-OpenCloudConfigRunning)) {
       $uptime = (Get-Uptime)
       if (($uptime) -and ($uptime -gt (New-TimeSpan -minutes 8))) {
-        if ((-not (Is-RdpSessionActive)) -and (-not (Is-DriveFormatInProgress))) {
+        if (-not (Is-RdpSessionActive)) {
           Write-Log -message ('instance failed productivity check and will be halted. uptime: {0}' -f $uptime) -severity 'ERROR'
           & shutdown @('-s', '-t', '0', '-c', 'HaltOnIdle :: instance failed productivity checks', '-f', '-d', 'p:4:1')
         } else {
-          Write-Log -message 'instance failed productivity checks and would be halted, but has rdp session in progress or is formatting a drive.' -severity 'DEBUG'
+          Write-Log -message 'instance failed productivity checks and would be halted, but has rdp session in progress.' -severity 'DEBUG'
         }
       } else {
         Write-Log -message 'instance failed productivity checks and will be retested shortly.' -severity 'WARN'

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1134,7 +1134,7 @@
           "ComponentName": "GenericWorkerInstall"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1134,7 +1134,7 @@
           "ComponentName": "GenericWorkerInstall"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1134,7 +1134,7 @@
           "ComponentName": "GenericWorkerInstall"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1134,7 +1134,7 @@
           "ComponentName": "GenericWorkerInstall"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -570,7 +570,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -570,7 +570,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -570,7 +570,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -570,7 +570,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -570,7 +570,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -667,7 +667,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -667,7 +667,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win7-32-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu-b.json
@@ -667,7 +667,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -667,7 +667,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -668,7 +668,7 @@
           "ComponentName": "DisableDesktopInterrupt"
         }
       ],
-      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-format-and-reboot.bat",
+      "Source": "https://raw.githubusercontent.com/mozilla-releng/OpenCloudConfig/master/userdata/Configuration/GenericWorker/run-generic-worker-and-reboot.bat",
       "Target": "C:\\generic-worker\\run-generic-worker.bat"
     },
     {

--- a/userdata/rundsc.ps1
+++ b/userdata/rundsc.ps1
@@ -1433,9 +1433,6 @@ if ($rebootReasons.length) {
       }
       if ((@(Get-Process | ? { $_.ProcessName -eq 'generic-worker' }).length -eq 0)) {
         Write-Log -message 'no generic-worker process detected.' -severity 'INFO'
-        & format @('Z:', '/fs:ntfs', '/v:""', '/q', '/y')
-        Write-Log -message 'Z: drive formatted.' -severity 'INFO'
-        #& net @('user', 'GenericWorker', (Get-ItemProperty -path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -name 'DefaultPassword').DefaultPassword)
         Remove-Item -Path $lock -force -ErrorAction SilentlyContinue
         if ($locationType -eq 'DataCenter') {
           Remove-Item -Path C:\dsc\task-claim-state.valid -force -ErrorAction SilentlyContinue


### PR DESCRIPTION
this pr removes drive formatting of the z: drive between generic worker task runs.
this is done in preparation for reducing the number of volumes since we don't want to format drives containing caches or other required data.
also in the gw wrapper script there were some lines relating to a deprecated loaner mechanism that have been redundant for some time and do nothing. i've removed them to help reduce the unnecessary complexity of this script.