### PR TITLE
 Bug 1509722 - disable windows defender & supporting services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,7 +323,7 @@ Instance configuration is defined in json format and currently includes implemen
   *example*:
   ```
   {
-    "ComponentName": "Reg_DisableService_WinDefend",
+    "ComponentName": "RegServiceStartupType_Manual_WinDefend",
     "ComponentType": "RegistryValueSet",
     "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
     "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",

--- a/readme.md
+++ b/readme.md
@@ -323,14 +323,14 @@ Instance configuration is defined in json format and currently includes implemen
   *example*:
   ```
   {
-    "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+    "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
     "ComponentType": "RegistryValueSet",
     "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
     "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
     "SetOwner": "S-1-5-32-544",
     "ValueName": "Start",
     "ValueType": "Dword",
-    "ValueData": "0x3",
+    "ValueData": "0x4",
     "Hex": true
   }
   ```

--- a/readme.md
+++ b/readme.md
@@ -318,18 +318,19 @@ Instance configuration is defined in json format and currently includes implemen
   }
   ```
 - **[RegistryValueSet](https://github.com/search?q=RegistryValueSet+language%3Apowershell+repo%3Amozilla-releng%2FOpenCloudConfig&type=Code)**:
-  Set a registry key and value or validate that the key already exists and contains the specified value
+  Set a registry key and value or validate that the key already exists and contains the specified value  (optionally assigning ownership of the registry key to a user sid specified by the SetOwner property. useful when a key has been protected from change using ACLs and/or obscure ownership)
 
   *example*:
   ```
   {
-    "ComponentName": "reg-WindowsErrorReportingDontShowUI",
+    "ComponentName": "Reg_DisableService_WinDefend",
     "ComponentType": "RegistryValueSet",
-    "Comment": "",
-    "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting",
-    "ValueName": "DontShowUI",
+    "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+    "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+    "SetOwner": "S-1-5-32-544",
+    "ValueName": "Start",
     "ValueType": "Dword",
-    "ValueData": "0x00000001",
+    "ValueData": "0x3",
     "Hex": true
   }
   ```

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1198,6 +1198,113 @@
       "Hex": true
     },
     {
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
       "ComponentName": "OpenSshDownload",
       "ComponentType": "FileDownload",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1198,131 +1198,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1330,20 +1205,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1355,22 +1222,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1198,109 +1198,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1205,7 +1205,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1216,7 +1216,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1227,7 +1227,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1238,7 +1238,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1249,7 +1249,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1270,7 +1270,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1291,7 +1291,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1198,7 +1198,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1210,12 +1221,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1233,12 +1244,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1250,12 +1261,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1267,7 +1278,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1278,7 +1289,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1289,25 +1300,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1237,16 +1237,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1254,16 +1258,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1271,38 +1279,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1198,131 +1198,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1330,20 +1205,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1355,22 +1222,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1198,109 +1198,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1205,7 +1205,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1216,7 +1216,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1227,7 +1227,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1238,7 +1238,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1249,7 +1249,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1270,7 +1270,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1291,7 +1291,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1198,20 +1198,109 @@
       "Hex": true
     },
     {
-      "ComponentName": "DisableWinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_WinDefend_DisableConfig"
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
         },
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_WinDefend_DisableAntiSpyware"
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1198,7 +1198,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1210,12 +1221,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1233,12 +1244,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1250,12 +1261,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1267,7 +1278,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1278,7 +1289,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1289,25 +1300,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1237,16 +1237,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1254,16 +1258,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1271,38 +1279,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1254,16 +1254,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1271,16 +1275,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1288,38 +1296,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1222,7 +1222,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1233,7 +1233,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1244,7 +1244,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1255,7 +1255,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1266,7 +1266,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1287,7 +1287,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1308,7 +1308,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1215,109 +1215,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1215,7 +1215,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1227,12 +1238,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1250,12 +1261,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1267,12 +1278,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1284,7 +1295,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1295,7 +1306,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1306,25 +1317,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1215,131 +1215,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1347,20 +1222,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1372,22 +1239,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1215,6 +1215,113 @@
       "Hex": true
     },
     {
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
       "ComponentName": "OpenSshDownload",
       "ComponentType": "FileDownload",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1454578",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1250,109 +1250,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1250,131 +1250,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1382,20 +1257,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1407,22 +1274,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1289,16 +1289,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1306,16 +1310,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1323,38 +1331,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1257,7 +1257,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1268,7 +1268,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1279,7 +1279,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1290,7 +1290,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1301,7 +1301,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1322,7 +1322,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1343,7 +1343,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1250,20 +1250,109 @@
       "Hex": true
     },
     {
-      "ComponentName": "DisableWinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_WinDefend_DisableConfig"
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
         },
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_WinDefend_DisableAntiSpyware"
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1250,7 +1250,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1262,12 +1273,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1285,12 +1296,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1302,12 +1313,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1319,7 +1330,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1330,7 +1341,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1341,25 +1352,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1521,7 +1521,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1532,7 +1532,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1543,7 +1543,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1554,7 +1554,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1565,7 +1565,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1586,7 +1586,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1607,7 +1607,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1514,109 +1514,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1329,14 +1329,6 @@
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
     },
     {
-      "ComponentName": "DisableWinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped"
-    },
-    {
       "ComponentName": "reg_SystemRestore",
       "ComponentType": "RegistryKeySet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1453138",
@@ -1502,9 +1494,9 @@
       ]
     },
     {
-      "ComponentName": "reg_DisableAntiSpyware",
+      "ComponentName": "Reg_WinDefend_DisableConfig",
       "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1453138",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
       "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender",
       "ValueName": "DisableConfig",
       "ValueType": "Dword",
@@ -1512,14 +1504,121 @@
       "Hex": true
     },
     {
-      "ComponentName": "reg_DisableAntiSpyware_exe",
+      "ComponentName": "Reg_WinDefend_DisableAntiSpyware",
       "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1453138",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
       "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender",
       "ValueName": "DisableAntiSpyware",
       "ValueType": "Dword",
       "ValueData": "0x00000001",
       "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
     },
     {
       "ComponentName": "vcredist_vs2015_x86",

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1553,16 +1553,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1570,16 +1574,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1587,38 +1595,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1514,131 +1514,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1646,20 +1521,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1671,22 +1538,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "vcredist_vs2015_x86",

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1514,7 +1514,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1526,12 +1537,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1549,12 +1560,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1566,12 +1577,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1583,7 +1594,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1594,7 +1605,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1605,25 +1616,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "vcredist_vs2015_x86",

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1316,14 +1316,6 @@
       "ValueData": "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
     },
     {
-      "ComponentName": "DisableWinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped"
-    },
-    {
       "ComponentName": "reg_SystemRestore",
       "ComponentType": "RegistryKeySet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1453138",
@@ -1489,9 +1481,9 @@
       ]
     },
     {
-      "ComponentName": "reg_DisableAntiSpyware",
+      "ComponentName": "Reg_WinDefend_DisableConfig",
       "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1453138",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
       "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender",
       "ValueName": "DisableConfig",
       "ValueType": "Dword",
@@ -1499,14 +1491,121 @@
       "Hex": true
     },
     {
-      "ComponentName": "reg_DisableAntiSpyware_exe",
+      "ComponentName": "Reg_WinDefend_DisableAntiSpyware",
       "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1453138",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
       "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender",
       "ValueName": "DisableAntiSpyware",
       "ValueType": "Dword",
       "ValueData": "0x00000001",
       "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
     },
     {
       "ComponentName": "vcredist_vs2015_x86",

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1501,131 +1501,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1633,20 +1508,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1658,22 +1525,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "vcredist_vs2015_x86",

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1540,16 +1540,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1557,16 +1561,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1574,38 +1582,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1501,7 +1501,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1513,12 +1524,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1536,12 +1547,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1553,12 +1564,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1570,7 +1581,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1581,7 +1592,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1592,25 +1603,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "vcredist_vs2015_x86",

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1501,109 +1501,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1508,7 +1508,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1519,7 +1519,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1530,7 +1530,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1541,7 +1541,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1552,7 +1552,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1573,7 +1573,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1594,7 +1594,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1198,131 +1198,6 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdBoot",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdBoot",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdFilter",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdFilter",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisDrv",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisDrv",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WdNisSvc",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WdNisSvc",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
-        }
-      ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_WinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
-      "DependsOn": [
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
-        }
-      ]
-    },
-    {
       "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
@@ -1330,20 +1205,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
-      "Hex": true
-    },
-    {
-      "ComponentName": "ServiceStop_SecurityHealthService",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "SecurityHealthService",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
         }
       ]
     },
@@ -1355,22 +1222,92 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "ServiceStop_Sense",
-      "ComponentType": "ServiceControl",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Name": "Sense",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
         }
       ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1198,109 +1198,177 @@
       "Hex": true
     },
     {
-      "ComponentName": "Reg_DisableService_WdNisDrv",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdNisSvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_SecurityHealthService",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_Sense",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
-    },
-    {
-      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdBoot",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdBoot",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdBoot"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdFilter",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdFilter",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
-        {
-          "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_WdFilter"
         }
       ]
     },
     {
-      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisDrv",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisDrv",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisDrv"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WdNisSvc",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WdNisSvc",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_WdNisSvc"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true,
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_WinDefend",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "WinDefend",
+      "StartupType": "Manual",
+      "State": "Stopped",
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_SecurityHealthService"
-        },
+          "ComponentName": "RegServiceStartupType_Manual_WinDefend"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_SecurityHealthService",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "SecurityHealthService",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_DisableService_Sense"
+          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+        }
+      ]
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "ServiceStop_Sense",
+      "ComponentType": "ServiceControl",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Name": "Sense",
+      "StartupType": "Manual",
+      "State": "Stopped",
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Manual_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1205,7 +1205,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1216,7 +1216,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1227,7 +1227,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1238,7 +1238,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
@@ -1249,7 +1249,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1270,7 +1270,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {
@@ -1291,7 +1291,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1198,20 +1198,109 @@
       "Hex": true
     },
     {
-      "ComponentName": "DisableWinDefend",
-      "ComponentType": "ServiceControl",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1365909",
-      "Name": "WinDefend",
-      "StartupType": "Manual",
-      "State": "Stopped",
+      "ComponentName": "Reg_DisableService_WdNisDrv",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdNisSvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_SecurityHealthService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_Sense",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdBoot",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_WinDefend_DisableConfig"
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
         },
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "Reg_WinDefend_DisableAntiSpyware"
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WdFilter",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
+        }
+      ]
+    },
+    {
+      "ComponentName": "Reg_DisableService_WinDefend",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x3",
+      "Hex": true,
+      "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_SecurityHealthService"
+        },
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "Reg_DisableService_Sense"
         }
       ]
     },

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1198,7 +1198,18 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService",
+      "ComponentName": "RegServiceStartupType_Disabled_wscsvc",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
+      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
+      "SetOwner": "S-1-5-32-544",
+      "ValueName": "Start",
+      "ValueType": "Dword",
+      "ValueData": "0x4",
+      "Hex": true
+    },
+    {
+      "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SecurityHealthService",
@@ -1210,12 +1221,12 @@
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_wscsvc"
+          "ComponentName": "RegServiceStartupType_Disabled_wscsvc"
         }
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_Sense",
+      "ComponentName": "RegServiceStartupType_Disabled_Sense",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Sense",
@@ -1233,12 +1244,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1250,12 +1261,12 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
     },
@@ -1267,7 +1278,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1278,7 +1289,7 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true
     },
     {
@@ -1289,25 +1300,14 @@
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x4",
+      "ValueData": "0x3",
       "Hex": true,
       "DependsOn": [
         {
           "ComponentType": "RegistryValueSet",
-          "ComponentName": "RegServiceStartupType_Manual_SecurityHealthService"
+          "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
         }
       ]
-    },
-    {
-      "ComponentName": "RegServiceStartupType_Manual_wscsvc",
-      "ComponentType": "RegistryValueSet",
-      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
-      "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\wscsvc",
-      "SetOwner": "S-1-5-32-544",
-      "ValueName": "Start",
-      "ValueType": "Dword",
-      "ValueData": "0x4",
-      "Hex": true
     },
     {
       "ComponentName": "OpenSshDownload",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1237,16 +1237,20 @@
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdBoot",
+      "ComponentName": "RegServiceStartupType_Disabled_WdBoot",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdBoot",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1254,16 +1258,20 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdFilter",
+      "ComponentName": "RegServiceStartupType_Disabled_WdFilter",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdFilter",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"
@@ -1271,38 +1279,42 @@
       ]
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisDrv",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisDrv",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisDrv",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WdNisSvc",
+      "ComponentName": "RegServiceStartupType_Disabled_WdNisSvc",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WdNisSvc",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true
     },
     {
-      "ComponentName": "RegServiceStartupType_Manual_WinDefend",
+      "ComponentName": "RegServiceStartupType_Disabled_WinDefend",
       "ComponentType": "RegistryValueSet",
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1509722",
       "Key": "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\WinDefend",
       "SetOwner": "S-1-5-32-544",
       "ValueName": "Start",
       "ValueType": "Dword",
-      "ValueData": "0x3",
+      "ValueData": "0x4",
       "Hex": true,
       "DependsOn": [
+        {
+          "ComponentType": "RegistryValueSet",
+          "ComponentName": "RegServiceStartupType_Disabled_Sense"
+        },
         {
           "ComponentType": "RegistryValueSet",
           "ComponentName": "RegServiceStartupType_Disabled_SecurityHealthService"

--- a/userdata/OCC-Bootstrap.psm1
+++ b/userdata/OCC-Bootstrap.psm1
@@ -1494,6 +1494,7 @@ function Wait-GenericWorkerStart {
           $gwProcess.PriorityClass = [Diagnostics.ProcessPriorityClass]::AboveNormal
           Write-Log -message ('{0} :: process priority for generic worker altered from {1} to {2}.' -f $($MyInvocation.MyCommand.Name), $priorityClass, $gwProcess.PriorityClass) -severity 'INFO'
           Set-ServiceState -name 'wuauserv' -state 'Stopped'
+          Set-ServiceState -name 'bits' -state 'Stopped'
         }
       }
     } else {

--- a/userdata/OCC-Bootstrap.psm1
+++ b/userdata/OCC-Bootstrap.psm1
@@ -1820,13 +1820,14 @@ function Invoke-OpenCloudConfig {
       
       # post dsc teardown ###########################################################################################################################################
       
-      if (((Get-Content $transcript) | % {
-        (
-          ($_ -match 'requires a reboot') -or ($_ -match 'reboot is required') # a package installed by dsc requested a restart
-          -or ($_ -match 'WSManNetworkFailureDetected') # a wsman network outage prevented the dsc run from completing
-          -or ($_ -match 'Attempted to perform an unauthorized operation.') # a service disable attempt through registry settings failed, because another running service interfered with the registry write
-        )
-      }) -contains $true) {
+      if (((Get-Content $transcript) | % {(
+          # a package installed by dsc requested a restart
+          ($_ -match 'requires a reboot') -or
+          ($_ -match 'reboot is required') -or
+          # a wsman network outage prevented the dsc run from completing
+          ($_ -match 'WSManNetworkFailureDetected') -or
+          # a service disable attempt through registry settings failed, because another running service interfered with the registry write
+          ($_ -match 'Attempted to perform an unauthorized operation.'))}) -contains $true) {
         if (-not ($isWorker)) {
           # ensure that Ec2HandleUserData is enabled before reboot (if the RunDesiredStateConfigurationAtStartup scheduled task doesn't yet exist)
           Set-Ec2ConfigSettings

--- a/userdata/OCC-Bootstrap.psm1
+++ b/userdata/OCC-Bootstrap.psm1
@@ -1819,13 +1819,20 @@ function Invoke-OpenCloudConfig {
       # end run dsc #################################################################################################################################################
       
       # post dsc teardown ###########################################################################################################################################
-      if (((Get-Content $transcript) | % { (($_ -match 'requires a reboot') -or ($_ -match 'reboot is required') -or ($_ -match 'WSManNetworkFailureDetected')) }) -contains $true) {
+      
+      if (((Get-Content $transcript) | % {
+        (
+          ($_ -match 'requires a reboot') -or ($_ -match 'reboot is required') # a package installed by dsc requested a restart
+          -or ($_ -match 'WSManNetworkFailureDetected') # a wsman network outage prevented the dsc run from completing
+          -or ($_ -match 'Attempted to perform an unauthorized operation.') # a service disable attempt through registry settings failed, because another running service interfered with the registry write
+        )
+      }) -contains $true) {
         if (-not ($isWorker)) {
           # ensure that Ec2HandleUserData is enabled before reboot (if the RunDesiredStateConfigurationAtStartup scheduled task doesn't yet exist)
           Set-Ec2ConfigSettings
         }
         Remove-Item -Path $lock -force -ErrorAction SilentlyContinue
-        & shutdown @('-r', '-t', '0', '-c', 'a package installed by dsc requested a restart or the dsc process did not complete', '-f', '-d', 'p:4:2')
+        & shutdown @('-r', '-t', '0', '-c', 'the dsc process did not complete and now requires a restart', '-f', '-d', 'p:4:2')
       }
       if (($locationType -ne 'DataCenter') -and (((Get-Content $transcript) | % { ($_ -match 'failed to execute Set-TargetResource') }) -contains $true)) {
         Write-Log -message ('{0} :: dsc run failed.' -f $($MyInvocation.MyCommand.Name)) -severity 'ERROR'


### PR DESCRIPTION
Updates to Windows 10 have changed ACL permissions and ownership of the registry keys which govern access to Windows service settings for services which support the running of Windows Defender:
- HKLM:\SYSTEM\CurrentControlSet\Services\WdBoot
- HKLM:\SYSTEM\CurrentControlSet\Services\WdFilter
- HKLM:\SYSTEM\CurrentControlSet\Services\WdNisDrv
- HKLM:\SYSTEM\CurrentControlSet\Services\WdNisSvc
- HKLM:\SYSTEM\CurrentControlSet\Services\WinDefend
- HKLM:\SYSTEM\CurrentControlSet\Services\wscsvc
- HKLM:\SYSTEM\CurrentControlSet\Services\SecurityHealthService
- HKLM:\SYSTEM\CurrentControlSet\Services\Sense

This prevents stopping or changing the service startup type for Windows services: WdBoot, WdFilter, WdNisDrv, WdNisSvc, WinDefend, SecurityHealthService & Sense using the normal Windows service stop or start commands, commandlets or service manager interface.

WinDefend will also occasionally fail to stop if wscsvc (Windows Security Center Service) is still running. wscsvc also sends alert to the user interface, if it detects that WinDefend is not running and fails to detect a third party alternative. For the special use case of Firefox UI testing, with screenshot pixel comparisons, it is necessary to prevent these alerts from being displayed and impacting test results.

Additionally, the Windows services *SecurityHealthService* & *Sense* monitor the registry keys for Windows services *WdBoot*, *WdFilter* & *WinDefend* and block any attempt to change the ownership or ACL settings for the services associated registry keys, even if the elevated process performing the modification has all the necessary access rights and privileges.

In order to disable Windows Defender on new Windows 10 systems or on systems where an update has locked modification of Windows Defender startup settings, it is necessary to:
- grant SeTakeOwnershipPrivilege, SeBackupPrivilege, SeRestorePrivilege to the elevated process which will modify ownership and ACL settings for the affected Windows services.
- set ownership of the registry path to a user account or group which the elevated process performing the modification is running under.
- modify the service startup type registry key (eg: HKLM:\SYSTEM\CurrentControlSet\Services\WinDefend\Start) to have a value of **0x3** (Manual) or **0x4** (Disabled).
- first perform the modification on Windows services: *SecurityHealthService* & *Sense* and ensure that these services have stopped (reboot if necessary) to prevent them from interfering with modification of other services.
- repeat the modification on Windows service: *wscsvc* to prevent that service from interfering with the disabling of the *WinDefend* service.
- finally repeat the modification on Windows services: *WdBoot*, *WdFilter*, *WdNisDrv*, *WdNisSvc* & *WinDefend*