### PR TITLE
Bug 1485628 - disable service pack updates & reboots

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -1542,7 +1542,7 @@
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1494048",
       "Command": "icacls.exe",
       "Arguments": [
-        "C:\\ProgramData\\Mozilla",
+        "c:\\ProgramData\\Mozilla",
         "/grant",
         "Everyone:(OI)(CI)F"
       ],
@@ -1551,19 +1551,7 @@
           "ComponentType": "CommandRun",
           "ComponentName": "maintenanceservice_install"
         }
-      ],
-      "Validate": {
-        "CommandsReturn": [
-          {
-            "Command": "icacls.exe",
-            "Arguments": [
-              "C:\\ProgramData\\Mozilla",
-              "/T"
-            ],
-            "Match": "Everyone:(OI)(CI)(F)"
-          }
-        ]
-      }
+      ]
     },
     {
       "ComponentName": "HostsFile",
@@ -1585,6 +1573,105 @@
           "ComponentName": "HostsFile"
         }
       ]
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgrade",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgrade",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgradePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgradePeriod",
+      "ValueType": "Dword",
+      "ValueData": 8
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpdatePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpdatePeriod",
+      "ValueType": "Dword",
+      "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
     }
   ],
   "ProvisionerConfiguration": {

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1573,6 +1573,105 @@
           "ComponentName": "HostsFile"
         }
       ]
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgrade",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgrade",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgradePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgradePeriod",
+      "ValueType": "Dword",
+      "ValueData": 8
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpdatePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpdatePeriod",
+      "ValueType": "Dword",
+      "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
     }
   ],
   "ProvisionerConfiguration": {

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -1141,6 +1141,41 @@
       ]
     },
     {
+      "ComponentName": "NvidiaK520DriverPackage",
+      "ComponentType": "ExeInstall",
+      "Comment": "Required for hardware acceleration on EC2 g2 (GPU) instances. http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/accelerated-computing-instances.html#install-nvidia-driver-windows",
+      "Url": "http://uk.download.nvidia.com/Windows/Quadro_Certified/GRID/369.95/369.95-quadro-grid-desktop-notebook-win10-64bit-international-whql.exe",
+      "Arguments": [
+        "/s"
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\NVIDIA\\369.95\\setup.exe"
+        ]
+      },
+      "sha512": "7fd87a38e5eb760e49bd136d238ec8983a9cdacc1dfc67334c1033f887aab3c8592156a7f876de7c8938279008848ff755ec478aab9c1218f7879ca6758e29f2"
+    },
+    {
+      "ComponentName": "NvidiaK520DriverInstall",
+      "ComponentType": "CommandRun",
+      "Comment": "Required for hardware acceleration on EC2 g2 (GPU) instances. http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/accelerated-computing-instances.html#install-nvidia-driver-windows",
+      "Command": "C:\\NVIDIA\\369.95\\setup.exe",
+      "Arguments": [
+        "/s"
+      ],
+      "Validate": {
+        "PathsExist": [
+          "C:\\Program Files\\NVIDIA Corporation\\license.txt"
+        ]
+      },
+      "DependsOn": [
+        {
+          "ComponentType": "ExeInstall",
+          "ComponentName": "NvidiaK520DriverPackage"
+        }
+      ]
+    },
+    {
       "ComponentName": "nircmd",
       "ComponentType": "FileDownload",
       "Source": "https://s3.amazonaws.com/windows-opencloudconfig-packages/nircmd/nircmd.exe",
@@ -1559,7 +1594,7 @@
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1494048",
       "Command": "icacls.exe",
       "Arguments": [
-        "C:\\ProgramData\\Mozilla",
+        "c:\\ProgramData\\Mozilla",
         "/grant",
         "Everyone:(OI)(CI)F"
       ],
@@ -1568,19 +1603,7 @@
           "ComponentType": "CommandRun",
           "ComponentName": "maintenanceservice_install"
         }
-      ],
-      "Validate": {
-        "CommandsReturn": [
-          {
-            "Command": "icacls.exe",
-            "Arguments": [
-              "C:\\ProgramData\\Mozilla",
-              "/T"
-            ],
-            "Match": "Everyone:(OI)(CI)(F)"
-          }
-        ]
-      }
+      ]
     },
     {
       "ComponentName": "HostsFile",
@@ -1602,6 +1625,105 @@
           "ComponentName": "HostsFile"
         }
       ]
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgrade",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgrade",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgradePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgradePeriod",
+      "ValueType": "Dword",
+      "ValueData": 8
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpdatePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpdatePeriod",
+      "ValueType": "Dword",
+      "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
     }
   ],
   "ProvisionerConfiguration": {

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -1141,41 +1141,6 @@
       ]
     },
     {
-      "ComponentName": "NvidiaK520DriverPackage",
-      "ComponentType": "ExeInstall",
-      "Comment": "Required for hardware acceleration on EC2 g2 (GPU) instances. http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/accelerated-computing-instances.html#install-nvidia-driver-windows",
-      "Url": "http://uk.download.nvidia.com/Windows/Quadro_Certified/GRID/369.95/369.95-quadro-grid-desktop-notebook-win10-64bit-international-whql.exe",
-      "Arguments": [
-        "/s"
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\NVIDIA\\369.95\\setup.exe"
-        ]
-      },
-      "sha512": "7fd87a38e5eb760e49bd136d238ec8983a9cdacc1dfc67334c1033f887aab3c8592156a7f876de7c8938279008848ff755ec478aab9c1218f7879ca6758e29f2"
-    },
-    {
-      "ComponentName": "NvidiaK520DriverInstall",
-      "ComponentType": "CommandRun",
-      "Comment": "Required for hardware acceleration on EC2 g2 (GPU) instances. http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/accelerated-computing-instances.html#install-nvidia-driver-windows",
-      "Command": "C:\\NVIDIA\\369.95\\setup.exe",
-      "Arguments": [
-        "/s"
-      ],
-      "Validate": {
-        "PathsExist": [
-          "C:\\Program Files\\NVIDIA Corporation\\license.txt"
-        ]
-      },
-      "DependsOn": [
-        {
-          "ComponentType": "ExeInstall",
-          "ComponentName": "NvidiaK520DriverPackage"
-        }
-      ]
-    },
-    {
       "ComponentName": "nircmd",
       "ComponentType": "FileDownload",
       "Source": "https://s3.amazonaws.com/windows-opencloudconfig-packages/nircmd/nircmd.exe",
@@ -1652,6 +1617,78 @@
       "ValueName": "DeferUpdatePeriod",
       "ValueType": "Dword",
       "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
     }
   ],
   "ProvisionerConfiguration": {

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -1730,6 +1730,105 @@
       ]
     },
     {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgrade",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgrade",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgradePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgradePeriod",
+      "ValueType": "Dword",
+      "ValueData": 8
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpdatePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpdatePeriod",
+      "ValueType": "Dword",
+      "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
       "ComponentName": "hw-startup-check_ps1",
       "ComponentType": "ChecksumFileDownload",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -1717,6 +1717,105 @@
       ]
     },
     {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgrade",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgrade",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpgradePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpgradePeriod",
+      "ValueType": "Dword",
+      "ValueData": 8
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_DeferUpdatePeriod",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1510220",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate",
+      "ValueName": "DeferUpdatePeriod",
+      "ValueType": "Dword",
+      "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
       "ComponentName": "hw-startup-check_ps1",
       "ComponentType": "ChecksumFileDownload",
       "Comment": "Maintenance Toolchain - not essential for building firefox",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -1600,6 +1600,78 @@
       "ValueName": "DeferUpdatePeriod",
       "ValueType": "Dword",
       "ValueData": 4
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoRebootWithLoggedOnUsers",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoRebootWithLoggedOnUsers",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_NoAutoUpdate",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "NoAutoUpdate",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AUOptions",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AUOptions",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallDay",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallDay",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_ScheduledInstallTime",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "ScheduledInstallTime",
+      "ValueType": "Dword",
+      "ValueData": 1
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AutomaticMaintenanceEnabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AutomaticMaintenanceEnabled",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_WindowsUpdate_AU_AllowMUUpdateService",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+      "ValueName": "AllowMUUpdateService",
+      "ValueType": "Dword",
+      "ValueData": 0
+    },
+    {
+      "ComponentName": "reg_ScheduleMaintenance_MaintenanceDisabled",
+      "ComponentType": "RegistryValueSet",
+      "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1485628",
+      "Key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Maintenance",
+      "ValueName": "MaintenanceDisabled",
+      "ValueType": "Dword",
+      "ValueData": 1
     }
   ],
   "ProvisionerConfiguration": {


### PR DESCRIPTION
this change sets a number of registry keys relating to windows update configuration. additionally, it synchronises a couple prod/beta manifests which had slightly diverged:
- gecko-t-win10-64 is synced with gecko-t-win10-64-beta 
- gecko-t-win10-64-gpu is synced with gecko-t-win10-64-gpu-b

the sync changes are just to keep beta and prod manifests the same, so that change tests on beta are valid when promoted to prod.

one of the sync changes is to remove the nvidia 520 driver from prod where we recently upgraded the base ami to use g3 instances which use a different nvidia driver. the 520 driver was used to support g2 instances whch are no longer used. on g3 we bake the nvidia grid driver into the ami during iso-to-ami conversion (see: https://github.com/mozilla-platform-ops/relops-image-builder/blob/f5c47c181647949c2a6fd84c47a2d486023f63a9/manifest.json#L110-L116)

another sync change is to add registry keys to beta which were added to prod yesterday (see: https://github.com/mozilla-releng/OpenCloudConfig/commit/c421eb84b254a74a84916ad5bd1d957bea060f33, https://bugzilla.mozilla.org/show_bug.cgi?id=1510220):

- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\DeferUpgrade: 1
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\DeferUpgradePeriod: 8
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\DeferUpdatePeriod: 4

the new registry key changes are:

- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoRebootWithLoggedOnUsers: 1
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate: 1
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\AUOptions: 1
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\ScheduledInstallDay: 1
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\ScheduledInstallTime: 1
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\AutomaticMaintenanceEnabled: 0
- HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\AllowMUUpdateService: 0
- HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\Maintenance\MaintenanceDisabled: 1

Some of these keys will be used now to fix the immediate problem with service pack updates and reboots (NoAutoRebootWithLoggedOnUsers, NoAutoUpdate, AUOptions).

The remaining keys are set so that we have a source controlled record of change if/when we enable automatic updates in future. The settings and their associated values are documented here: https://support.microsoft.com/en-us/help/328010/how-to-configure-automatic-updates-by-using-group-policy-or-registry-s