### PR TITLE
Bug 1524592 - include `--configure-for-aws` option when installing generic-worker

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1053,7 +1053,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -521,7 +521,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -521,7 +521,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -521,7 +521,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-gpu-a.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-a.json
@@ -521,7 +521,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -521,7 +521,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -521,7 +521,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win10-64-ux-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux-b.json
@@ -744,7 +744,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win64\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -636,7 +636,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win32\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -636,7 +636,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win32\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {

--- a/userdata/Manifest/gecko-t-win7-32-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu-b.json
@@ -636,7 +636,8 @@
         "--nssm",
         "C:\\nssm-2.24-103-gdee49fc\\win32\\nssm.exe",
         "--config",
-        "C:\\generic-worker\\generic-worker.config"
+        "C:\\generic-worker\\generic-worker.config",
+        "--configure-for-aws"
       ],
       "DependsOn": [
         {


### PR DESCRIPTION
See [generic-worker 11.0.0 release notes](https://github.com/taskcluster/generic-worker#in-v1100-since-v10113) for details.

Useful (although not necessary) for [bug 1524592](https://bugzil.la/1524592).