### PR TITLE
Align gecko-t-win{7-32,10-64}-cu manifests with gecko-t-win{7-32,10-64} manifests

### DIFF
--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -1561,7 +1561,7 @@
       "Comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1494048",
       "Command": "icacls.exe",
       "Arguments": [
-        "c:\\ProgramData\\Mozilla",
+        "C:\\ProgramData\\Mozilla",
         "/grant",
         "Everyone:(OI)(CI)F"
       ],
@@ -1570,7 +1570,19 @@
           "ComponentType": "CommandRun",
           "ComponentName": "maintenanceservice_install"
         }
-      ]
+      ],
+      "Validate": {
+        "CommandsReturn": [
+          {
+            "Command": "icacls.exe",
+            "Arguments": [
+              "C:\\ProgramData\\Mozilla",
+              "/T"
+            ],
+            "Match": "Everyone:(OI)(CI)(F)"
+          }
+        ]
+      }
     },
     {
       "ComponentName": "HostsFile",

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -506,7 +506,8 @@
         "C:\\mozilla-build\\python3",
         "C:\\mozilla-build\\upx391w",
         "C:\\mozilla-build\\wget",
-        "C:\\mozilla-build\\yasm"
+        "C:\\mozilla-build\\yasm",
+        "C:\\Program Files\\Microsoft Windows Performance Toolkit"
       ],
       "Target": "Machine"
     },
@@ -1506,40 +1507,40 @@
   "ProvisionerConfiguration": {
     "instanceTypes": [
       {
-        "capacity": 1,
         "instanceType": "c4.2xlarge",
+        "capacity": 1,
+        "utility": 1,
+        "secrets": {},
+        "scopes": [],
+        "userData": {},
         "launchSpec": {
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
               "Ebs": {
-                "DeleteOnTermination": true,
+                "VolumeType": "gp2",
                 "VolumeSize": 30,
-                "VolumeType": "gp2"
+                "DeleteOnTermination": true
               }
             },
             {
               "DeviceName": "/dev/sdb",
               "Ebs": {
-                "DeleteOnTermination": true,
+                "VolumeType": "gp2",
                 "VolumeSize": 120,
-                "VolumeType": "gp2"
+                "DeleteOnTermination": true
               }
             },
             {
               "DeviceName": "/dev/sdc",
               "Ebs": {
-                "DeleteOnTermination": true,
+                "VolumeType": "gp2",
                 "VolumeSize": 120,
-                "VolumeType": "gp2"
+                "DeleteOnTermination": true
               }
             }
           ]
-        },
-        "scopes": [],
-        "secrets": {},
-        "userData": {},
-        "utility": 1
+        }
       }
     ],
     "userData": {


### PR DESCRIPTION
Hey Rob,

This patches the `*-cu` manifests to be consistent with their non `-cu` counterparts.

Thanks!