### PR TITLE
Bug 1534983 - upgrade generic-worker from 13.0.2 to 13.0.4

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012-c4.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c4.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012-c5.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c5.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu-a.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-a.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -553,9 +553,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "959b2fbf2bcaaf36039be0f6d34d1f8da6ad86e071d056da119acbf7d460b170a9c070351b6222c296c1486aeb880e39f426a7ec7bacbe8cda09800346f4e1b7"
+      "sha512": "a6e4bae5a225c91816b7232e249c77d602af03207a3e38468c6c8da69b43e47edf5ea2aa3b3d2f9bb518f7fb036f0aebea0ae5d5cb846e40fd2aac5f7635bd65"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -678,7 +678,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -750,9 +750,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "959b2fbf2bcaaf36039be0f6d34d1f8da6ad86e071d056da119acbf7d460b170a9c070351b6222c296c1486aeb880e39f426a7ec7bacbe8cda09800346f4e1b7"
+      "sha512": "a6e4bae5a225c91816b7232e249c77d602af03207a3e38468c6c8da69b43e47edf5ea2aa3b3d2f9bb518f7fb036f0aebea0ae5d5cb846e40fd2aac5f7635bd65"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -821,7 +821,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -554,9 +554,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "959b2fbf2bcaaf36039be0f6d34d1f8da6ad86e071d056da119acbf7d460b170a9c070351b6222c296c1486aeb880e39f426a7ec7bacbe8cda09800346f4e1b7"
+      "sha512": "a6e4bae5a225c91816b7232e249c77d602af03207a3e38468c6c8da69b43e47edf5ea2aa3b3d2f9bb518f7fb036f0aebea0ae5d5cb846e40fd2aac5f7635bd65"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -679,7 +679,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }

--- a/userdata/Manifest/relops-image-builder.json
+++ b/userdata/Manifest/relops-image-builder.json
@@ -230,9 +230,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.4/generic-worker-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "03ea0214da20fe58d6725cd0c1e5a21850f4b82dd78fedf39499882d211909f634d6a9e0b7af9458667318847820bbd2b70c6b1af0ba647066c4decc6f983d6c"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -351,7 +351,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 13.0.4 *"
           }
         ]
       }


### PR DESCRIPTION
Try push on staging worker types:
https://treeherder.mozilla.org/#/jobs?repo=try&revision=0d5a0411f4070cb119ce8c4b48fb714e972844d4

Thanks!

See [bug 1534983](https://bugzil.la/1534983) for details.