### PR TITLE
Revert "Revert "Bug 1534983 - Upgrade to generic-worker 14.0.2""

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1529,7 +1529,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1523,7 +1523,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-3-b-win2012-c4.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c4.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1348,7 +1348,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-3-b-win2012-c5.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c5.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1348,7 +1348,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1089,7 +1089,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1379,7 +1379,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1651,7 +1651,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-t-win10-64-gpu-a.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-a.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1668,7 +1668,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1755,7 +1755,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -564,7 +564,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1750,7 +1750,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -553,9 +553,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "959b2fbf2bcaaf36039be0f6d34d1f8da6ad86e071d056da119acbf7d460b170a9c070351b6222c296c1486aeb880e39f426a7ec7bacbe8cda09800346f4e1b7"
+      "sha512": "3a471058c47533282831ae721415090907b0ba565a76a8c247f819defc32c754f30b08ec674d4407aedb8bd452966ce7945686dc16b61a9b17348adc1fefda01"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -678,7 +678,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1556,7 +1556,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -554,9 +554,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "959b2fbf2bcaaf36039be0f6d34d1f8da6ad86e071d056da119acbf7d460b170a9c070351b6222c296c1486aeb880e39f426a7ec7bacbe8cda09800346f4e1b7"
+      "sha512": "3a471058c47533282831ae721415090907b0ba565a76a8c247f819defc32c754f30b08ec674d4407aedb8bd452966ce7945686dc16b61a9b17348adc1fefda01"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -679,7 +679,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -1557,7 +1557,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",

--- a/userdata/Manifest/relops-image-builder.json
+++ b/userdata/Manifest/relops-image-builder.json
@@ -230,9 +230,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v13.0.2/generic-worker-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v14.0.2/generic-worker-nativeEngine-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e9cb9b8d69d9800b90733b2ac45d36f714f237d29e58f3eb250084ab09d547027fdc824ce6d2178e1d3269b8e32ab078d7c9c091e90f5ec72a39febe2e566019"
+      "sha512": "274346cc7232b801b3b2447272ec84a14532ff1b745549b28d42caed85a5693bdb5d6a6f09d7a2194d5da90c1871caf2a5310f984688f9d1eecd763c3e14bf00"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -351,7 +351,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker 13.0.2 *"
+            "Like": "generic-worker 14.0.2 *"
           }
         ]
       }
@@ -785,7 +785,6 @@
           "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
-          "openpgpSigningKeyLocation": "C:\\generic-worker\\openpgp-private.key",
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
           "runTasksAsCurrentUser": false,
           "sentryProject": "generic-worker",


### PR DESCRIPTION
Reverts mozilla-releng/OpenCloudConfig#234, which itself reverted #233 - in other words, this PR is a second attempt to land #233 ([bug 1534983](https://bugzil.la/1534983)).

Initially #233 was reverted due to [bug 1543353](https://bugzil.la/1543353) - however the root cause was later discovered to be [bug 1543490](https://bugzil.la/1543490) which resulted in #235 which has since landed. Therefore it should be safe to land #233 again.