### PR TITLE
Bug 1543227 - send logs to mc papertrail (rather than th)

### DIFF
--- a/ci/papertrail-setup.sh
+++ b/ci/papertrail-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+current_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+current_script_name=$(basename ${0##*/} .sh)
+
+papertrail_token=$(pass Mozilla/papertrail/grenade-token)
+
+gem install papertrail
+echo "token: ${papertrail_token}" > /tmp/papertrail.yml
+
+for manifest in $(ls ${current_script_dir}/../userdata/Manifest/gecko-*.json); do
+  workerType=$(basename ${manifest##*/} .json)
+  papertrail-add-group -g worker/${workerType} -w *.${workerType}.* -c /tmp/papertrail.yml
+done
+
+rm -f /tmp/papertrail.yml

--- a/userdata/Configuration/nxlog/gecko-3-b-win2012.conf
+++ b/userdata/Configuration/nxlog/gecko-3-b-win2012.conf
@@ -128,8 +128,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();

--- a/userdata/Configuration/nxlog/hw-win10.conf
+++ b/userdata/Configuration/nxlog/hw-win10.conf
@@ -115,8 +115,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();

--- a/userdata/Configuration/nxlog/win10.conf
+++ b/userdata/Configuration/nxlog/win10.conf
@@ -129,8 +129,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();

--- a/userdata/Configuration/nxlog/win10arm64.conf
+++ b/userdata/Configuration/nxlog/win10arm64.conf
@@ -109,8 +109,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();

--- a/userdata/Configuration/nxlog/win2012.conf
+++ b/userdata/Configuration/nxlog/win2012.conf
@@ -129,8 +129,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();

--- a/userdata/Configuration/nxlog/win2016.conf
+++ b/userdata/Configuration/nxlog/win2016.conf
@@ -128,8 +128,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();

--- a/userdata/Configuration/nxlog/win7.conf
+++ b/userdata/Configuration/nxlog/win7.conf
@@ -129,8 +129,8 @@ LogFile   %ROOT%\data\nxlog.log
 
 <Output papertrail>
   Module om_ssl
-  Host logs3.papertrailapp.com
-  Port 49853
+  Host logs.papertrailapp.com
+  Port 52806
   CAFile %ROOT%\cert\papertrail-bundle.pem
   AllowUntrusted FALSE
   Exec $Hostname = hostname_fqdn();


### PR DESCRIPTION
i've created a new log destination in the papertrail "Mozilla Corporation" (releng) account and i have run the setup script included in this patch (it creates worker type specific pt groups matching those that exist in the treeherder account.