### PR TITLE
Bug 1547966 - configure to use websocktunnel

### DIFF
--- a/userdata/Configuration/GenericWorker/generic-worker.config
+++ b/userdata/Configuration/GenericWorker/generic-worker.config
@@ -3,10 +3,7 @@
   "cleanUpTaskDirs": true,
   "disableReboots": true,
   "downloadsDir": "Z:\\downloads",
-  "livelogCertificate": "C:\\generic-worker\\livelog.crt",
   "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-  "livelogGETPort": 60023,
-  "livelogKey": "C:\\generic-worker\\livelog.key",
   "livelogPUTPort": 60022,
   "numberOfTasksToRun": 0,
   "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -14,8 +11,9 @@
   "shutdownMachineOnIdle": false,
   "shutdownMachineOnInternalError": true,
   "signingKeyLocation": "C:\\generic-worker\\cot.key",
-  "subdomain": "taskcluster-worker.net",
   "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
   "taskclusterProxyPort": 80,
-  "tasksDir": "Z:\\"
+  "tasksDir": "Z:\\",
+  "wstAudience": "taskcluster-net",
+  "wstServerURL": "https://websocktunnel.tasks.build"
 }

--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -995,22 +995,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1523,10 +1507,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1534,10 +1515,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -995,22 +995,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1523,10 +1507,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1534,10 +1515,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -995,22 +995,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1517,10 +1501,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1528,10 +1509,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-3-b-win2012-c4.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c4.json
@@ -995,22 +995,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1342,10 +1326,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1353,10 +1334,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-3-b-win2012-c5.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c5.json
@@ -995,22 +995,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1342,10 +1326,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1353,10 +1334,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -995,22 +995,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1373,10 +1357,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1384,10 +1365,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-alpha.json
+++ b/userdata/Manifest/gecko-t-win10-64-alpha.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1645,10 +1629,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1656,10 +1637,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-64-beta.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1732,10 +1716,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1743,10 +1724,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-cu.json
+++ b/userdata/Manifest/gecko-t-win10-64-cu.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1744,10 +1728,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1755,10 +1736,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-gpu-a.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-a.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1662,10 +1646,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1673,10 +1654,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-b.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1784,10 +1768,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1795,10 +1776,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1749,10 +1733,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1760,10 +1741,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-64-hw-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw-b.json
@@ -699,22 +699,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",

--- a/userdata/Manifest/gecko-t-win10-64-hw.json
+++ b/userdata/Manifest/gecko-t-win10-64-hw.json
@@ -700,22 +700,6 @@
       "sha512": "83dd123441f6bc0336103b65716ad016715864840055e07ec1959f74cd68b7e9cf5fc6e7e1034d7d4802486f1cbddc342475a61e49da06a878c3f74b8652d193"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",

--- a/userdata/Manifest/gecko-t-win10-64-ux-b.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux-b.json
@@ -686,22 +686,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",

--- a/userdata/Manifest/gecko-t-win10-64-ux.json
+++ b/userdata/Manifest/gecko-t-win10-64-ux.json
@@ -687,22 +687,6 @@
       "sha512": "83dd123441f6bc0336103b65716ad016715864840055e07ec1959f74cd68b7e9cf5fc6e7e1034d7d4802486f1cbddc342475a61e49da06a878c3f74b8652d193"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -470,22 +470,6 @@
       "sha512": "66dc995d3950f92e4007e0d021ff66d7ce9e9c45e95dd1295b31dc01362f558df893d5db6cec85b2b3832172be454acc0ca079447e7b99fdddb47a58ea84f2f9"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1744,10 +1728,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1755,10 +1736,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win10-a64-beta.json
+++ b/userdata/Manifest/gecko-t-win10-a64-beta.json
@@ -504,22 +504,6 @@
       "sha512": "83ec125f0fa8b8989e28cefa3b35c560556bf518c446f406a6320f758f6aaecac8b9e43a234cb1f2bdeb8d5126d68182aecfb2824b22668f3119812e2f587b25"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",

--- a/userdata/Manifest/gecko-t-win7-32-beta.json
+++ b/userdata/Manifest/gecko-t-win7-32-beta.json
@@ -584,22 +584,6 @@
       "sha512": "83ec125f0fa8b8989e28cefa3b35c560556bf518c446f406a6320f758f6aaecac8b9e43a234cb1f2bdeb8d5126d68182aecfb2824b22668f3119812e2f587b25"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1567,10 +1551,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1578,10 +1559,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win7-32-cu.json
+++ b/userdata/Manifest/gecko-t-win7-32-cu.json
@@ -585,22 +585,6 @@
       "sha512": "83ec125f0fa8b8989e28cefa3b35c560556bf518c446f406a6320f758f6aaecac8b9e43a234cb1f2bdeb8d5126d68182aecfb2824b22668f3119812e2f587b25"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1551,10 +1535,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1562,10 +1543,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win7-32-gpu-b.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu-b.json
@@ -584,22 +584,6 @@
       "sha512": "83ec125f0fa8b8989e28cefa3b35c560556bf518c446f406a6320f758f6aaecac8b9e43a234cb1f2bdeb8d5126d68182aecfb2824b22668f3119812e2f587b25"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1562,10 +1546,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1573,10 +1554,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -584,22 +584,6 @@
       "sha512": "83ec125f0fa8b8989e28cefa3b35c560556bf518c446f406a6320f758f6aaecac8b9e43a234cb1f2bdeb8d5126d68182aecfb2824b22668f3119812e2f587b25"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1550,10 +1534,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1561,10 +1542,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/gecko-t-win7-32-hw.json
+++ b/userdata/Manifest/gecko-t-win7-32-hw.json
@@ -767,22 +767,6 @@
       "Target": "C:\\generic-worker\\livelog.exe"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "GenericWorkerInstall",
       "ComponentType": "CommandRun",
       "Command": "C:\\generic-worker\\generic-worker.exe",

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -585,22 +585,6 @@
       "sha512": "83ec125f0fa8b8989e28cefa3b35c560556bf518c446f406a6320f758f6aaecac8b9e43a234cb1f2bdeb8d5126d68182aecfb2824b22668f3119812e2f587b25"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -1551,10 +1535,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -1562,10 +1543,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }

--- a/userdata/Manifest/relops-image-builder.json
+++ b/userdata/Manifest/relops-image-builder.json
@@ -259,22 +259,6 @@
       "Target": "C:\\generic-worker\\taskcluster-proxy.exe"
     },
     {
-      "ComponentName": "LiveLog_Get",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60022,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
-      "ComponentName": "LiveLog_Put",
-      "ComponentType": "FirewallRule",
-      "Protocol": "TCP",
-      "LocalPort": 60023,
-      "Direction": "Inbound",
-      "Action": "Allow"
-    },
-    {
       "ComponentName": "NSSMDownload",
       "ComponentType": "FileDownload",
       "Source": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
@@ -779,10 +763,7 @@
           "disableReboots": true,
           "downloadsDir": "Z:\\downloads",
           "ed25519SigningKeyLocation": "C:\\generic-worker\\ed25519-private.key",
-          "livelogCertificate": "C:\\generic-worker\\livelog.crt",
           "livelogExecutable": "C:\\generic-worker\\livelog.exe",
-          "livelogGETPort": 60023,
-          "livelogKey": "C:\\generic-worker\\livelog.key",
           "livelogPUTPort": 60022,
           "numberOfTasksToRun": 0,
           "runAfterUserCreation": "C:\\generic-worker\\task-user-init.cmd",
@@ -790,10 +771,11 @@
           "sentryProject": "generic-worker",
           "shutdownMachineOnIdle": false,
           "shutdownMachineOnInternalError": true,
-          "subdomain": "taskcluster-worker.net",
           "taskclusterProxyExecutable": "C:\\generic-worker\\taskcluster-proxy.exe",
           "taskclusterProxyPort": 80,
-          "tasksDir": "Z:\\"
+          "tasksDir": "Z:\\",
+          "wstAudience": "taskcluster-net",
+          "wstServerURL": "https://websocktunnel.tasks.build"
         }
       }
     }


### PR DESCRIPTION
In this condition, incoming access on the livelog GET port (60023,
mistakenly labeled as livelog PUT in the firewall rules) no longer
requires inbound access.  The PUT port never required inbound access --
it is only used on localhost.