### PR TITLE
Deploying generic-worker 15.1.1 / taskcluster-proxy 5.1.0 to PRODUCTION

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "e60046d319bb890e745906f63a3a3e8c9cc9dcba76497c25a6622009ffb6378c4eba284f87fef17ca7e09552b6f72bbfef9bcbf42c6a4e437ceec3bb3831d4ab"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1065,7 +1065,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "e60046d319bb890e745906f63a3a3e8c9cc9dcba76497c25a6622009ffb6378c4eba284f87fef17ca7e09552b6f72bbfef9bcbf42c6a4e437ceec3bb3831d4ab"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1065,7 +1065,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -964,9 +964,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "e60046d319bb890e745906f63a3a3e8c9cc9dcba76497c25a6622009ffb6378c4eba284f87fef17ca7e09552b6f72bbfef9bcbf42c6a4e437ceec3bb3831d4ab"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1065,7 +1065,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "e60046d319bb890e745906f63a3a3e8c9cc9dcba76497c25a6622009ffb6378c4eba284f87fef17ca7e09552b6f72bbfef9bcbf42c6a4e437ceec3bb3831d4ab"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -540,7 +540,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -439,9 +439,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "e60046d319bb890e745906f63a3a3e8c9cc9dcba76497c25a6622009ffb6378c4eba284f87fef17ca7e09552b6f72bbfef9bcbf42c6a4e437ceec3bb3831d4ab"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -540,7 +540,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -706,9 +706,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e2026cd40057b5b6ad93a419c0a90c78bcfbab5384d0bf3a76bd2bda51892ab518ac1eaa02dce722f6a45526c38ddf53fe7c8f4512bb763746b7bad74221a059"
+      "sha512": "d2826fb276a4dd1b1bd403467d977cbe8bce055fdceb48e99074fce79c30903a92c6c75f13b9ba977b69195d963f6446abaa86776f045ccab22e1619c54147ad"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -807,7 +807,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -707,9 +707,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.1/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e2026cd40057b5b6ad93a419c0a90c78bcfbab5384d0bf3a76bd2bda51892ab518ac1eaa02dce722f6a45526c38ddf53fe7c8f4512bb763746b7bad74221a059"
+      "sha512": "d2826fb276a4dd1b1bd403467d977cbe8bce055fdceb48e99074fce79c30903a92c6c75f13b9ba977b69195d963f6446abaa86776f045ccab22e1619c54147ad"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -808,7 +808,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.1 *"
           }
         ]
       }


### PR DESCRIPTION
Commit made with:

    ./gecko-try.sh -p -b gw-15.1.1 15.1.1 5.1.0

See https://github.com/taskcluster/generic-worker/blob/6737dbf737dd0cc52a8593861046e4442795485b/mozilla-try-scripts/gecko-try.sh

Hey Rob,

Based on [this successful try push](https://treeherder.mozilla.org/#/jobs?repo=try&selectedJob=256213619&revision=772e7f099df88b45e2c2c29b9424fadeb1704171&group_state=expanded), we should be good to deploy generic-worker 15.1.1 to production. No urgency. Thanks!

In v15.1.1 since v15.1.0
========================

* [Bug 1382668 - generic-worker: document the env vars that the worker implicitly sets in the task commands it runs](https://bugzil.la/1382668)
* [Bug 1562964 - generic-worker: log HTTP response body when getting a bad HTTP response code from the queue when uploading artifacts](https://bugzil.la/1562964)
* [Bug 1564354 - generic-worker: use generic-worker sentry project by default](https://bugzil.la/1564354)
* [Bug 1564361 - generic-worker: log system failures when checking if chain of trust key is readable](https://bugzil.la/1564361)