### PR TITLE
Bug 1562686 - stop providing IamInstanceProfile as it is unnecesary

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-beta.json
+++ b/userdata/Manifest/gecko-1-b-win2012-beta.json
@@ -1505,9 +1505,6 @@
         "capacity": 1,
         "utility": 0.9,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1536,9 +1533,6 @@
         "capacity": 1,
         "utility": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",

--- a/userdata/Manifest/gecko-1-b-win2012-xlarge.json
+++ b/userdata/Manifest/gecko-1-b-win2012-xlarge.json
@@ -1505,9 +1505,6 @@
         "utility": 1.1,
         "capacity": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1536,9 +1533,6 @@
         "utility": 1.1,
         "capacity": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1567,9 +1561,6 @@
         "capacity": 1,
         "utility": 0.9,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1598,9 +1589,6 @@
         "utility": 1,
         "capacity": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1629,9 +1617,6 @@
         "utility": 0.9,
         "capacity": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1505,9 +1505,6 @@
         "capacity": 1,
         "utility": 0.9,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1536,9 +1533,6 @@
         "capacity": 1,
         "utility": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-1-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",

--- a/userdata/Manifest/gecko-3-b-win2012-c4.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c4.json
@@ -1355,9 +1355,6 @@
         "capacity": 1,
         "utility": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-3-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",

--- a/userdata/Manifest/gecko-3-b-win2012-c5.json
+++ b/userdata/Manifest/gecko-3-b-win2012-c5.json
@@ -1355,9 +1355,6 @@
         "capacity": 1,
         "utility": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-3-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1355,9 +1355,6 @@
         "capacity": 1,
         "utility": 0.9,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-3-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",
@@ -1386,9 +1383,6 @@
         "capacity": 1,
         "utility": 1,
         "launchSpec": {
-          "IamInstanceProfile": {
-            "Arn": "arn:aws:iam::692406183521:instance-profile/taskcluster-level-3-sccache"
-          },
           "BlockDeviceMappings": [
             {
               "DeviceName": "/dev/sda1",


### PR DESCRIPTION
This will need to wait a bit to land, until the patch on [bug 1562686](https://bugzilla.mozilla.org/show_bug.cgi?id=1562686) has merged around.  It's my understanding that sccache is not used for release builds, so we won't need this on release or ESR branches.