### PR TITLE
Bug 1566365: deploy generic-worker 15.1.5

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1028,9 +1028,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1129,7 +1129,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1028,9 +1028,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1129,7 +1129,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1028,9 +1028,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1129,7 +1129,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -503,9 +503,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -604,7 +604,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -503,9 +503,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -604,7 +604,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -770,9 +770,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e2026cd40057b5b6ad93a419c0a90c78bcfbab5384d0bf3a76bd2bda51892ab518ac1eaa02dce722f6a45526c38ddf53fe7c8f4512bb763746b7bad74221a059"
+      "sha512": "fa5dc84943aa1ca386bd25709c31c2c25ea54f7ddc37a450c42caa8e771015112d107aeefc8313cc4f7fa2bfa33fbc085d27b3005fb80187cfbf1b4724368c1e"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -871,7 +871,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -771,9 +771,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "e2026cd40057b5b6ad93a419c0a90c78bcfbab5384d0bf3a76bd2bda51892ab518ac1eaa02dce722f6a45526c38ddf53fe7c8f4512bb763746b7bad74221a059"
+      "sha512": "fa5dc84943aa1ca386bd25709c31c2c25ea54f7ddc37a450c42caa8e771015112d107aeefc8313cc4f7fa2bfa33fbc085d27b3005fb80187cfbf1b4724368c1e"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -872,7 +872,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 15.1.5 *"
           }
         ]
       }


### PR DESCRIPTION
This upgrades generic-worker to version 15.1.5.

See [bug 1566365](https://bugzil.la/1566365) for more details.