### PR TITLE
Bug 1536780 - deploy generic-worker 16.2.0 to *PRODUCTION*

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1028,9 +1028,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
+      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1129,7 +1129,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1028,9 +1028,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
+      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1129,7 +1129,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1028,9 +1028,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
+      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1129,7 +1129,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -503,9 +503,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
+      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -604,7 +604,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -503,9 +503,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "9c0de3bf38cf584b9992a7487f0069cf759dd45541e36ab55aa7c40fc58baa3bb9ee34c12753d13a79676ed78d1bfad17a9725410cf1bc7efa4a122f83e88fdd"
+      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -604,7 +604,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -770,9 +770,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "fa5dc84943aa1ca386bd25709c31c2c25ea54f7ddc37a450c42caa8e771015112d107aeefc8313cc4f7fa2bfa33fbc085d27b3005fb80187cfbf1b4724368c1e"
+      "sha512": "0817b81c241abc5849b543348ff2493656325ad693e7b808c154f92c837a2ea3a0cce27d8a8aed7ca460c3f0403b0b5b5b386b72cf718b0d6f39a2426479778a"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -871,7 +871,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -771,9 +771,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.5/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "fa5dc84943aa1ca386bd25709c31c2c25ea54f7ddc37a450c42caa8e771015112d107aeefc8313cc4f7fa2bfa33fbc085d27b3005fb80187cfbf1b4724368c1e"
+      "sha512": "0817b81c241abc5849b543348ff2493656325ad693e7b808c154f92c837a2ea3a0cce27d8a8aed7ca460c3f0403b0b5b5b386b72cf718b0d6f39a2426479778a"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -872,7 +872,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.5 *"
+            "Like": "generic-worker (multiuser engine) 16.2.0 *"
           }
         ]
       }


### PR DESCRIPTION
See [bug 1536780](https://bugzil.la/1536780) for details.

Commit made with:

[gecko-try.sh](https://github.com/taskcluster/generic-worker/blob/165a50ac13ef09b6b2de65905c3aee82bd09bf5b/mozilla-try-scripts/gecko-try.sh) -p -b bug1536780 16.2.0 5.1.0

* [Successful try push](https://treeherder.mozilla.org/#/jobs?repo=try&group_state=expanded&revision=3f8e233f8ad8b018f51c6a1d78d0f8b73a9c5c09)
* [Release notes](https://github.com/taskcluster/generic-worker#release-notes)