### PR TITLE
Deploying generic-worker 16.3.0 / taskcluster-proxy 5.1.0 to *PRODUCT…

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1046,9 +1046,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
+      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1147,7 +1147,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1046,9 +1046,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
+      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1147,7 +1147,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1046,9 +1046,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
+      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1147,7 +1147,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -521,9 +521,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
+      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -622,7 +622,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -521,9 +521,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "ff498200e53ae486ca2a14b319abe51eadf0db45a9b5abc76b6389678bcbfc9f024edce12be8b7c4f36aa7d93bf1b872011b2ff3fa039385177fadfbdb4b055d"
+      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -622,7 +622,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -788,9 +788,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "0817b81c241abc5849b543348ff2493656325ad693e7b808c154f92c837a2ea3a0cce27d8a8aed7ca460c3f0403b0b5b5b386b72cf718b0d6f39a2426479778a"
+      "sha512": "b6fc9df9db5ee7fbdb9a6df7b05dba5405c5dc78e94e5fdfdb32fa745b19afd83f094dfe389665af304aa7ecb6aa7f453d379a0f84ee5147fa6a518c78423fd1"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -889,7 +889,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -789,9 +789,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.2.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "0817b81c241abc5849b543348ff2493656325ad693e7b808c154f92c837a2ea3a0cce27d8a8aed7ca460c3f0403b0b5b5b386b72cf718b0d6f39a2426479778a"
+      "sha512": "b6fc9df9db5ee7fbdb9a6df7b05dba5405c5dc78e94e5fdfdb32fa745b19afd83f094dfe389665af304aa7ecb6aa7f453d379a0f84ee5147fa6a518c78423fd1"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -890,7 +890,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.2.0 *"
+            "Like": "generic-worker (multiuser engine) 16.3.0 *"
           }
         ]
       }


### PR DESCRIPTION
…ION*.

Commit made with:

    mozilla-try-scripts/gecko-try.sh -p -b bug1587471 16.3.0 5.1.0

See https://github.com/taskcluster/generic-worker/blob/2e606756a3f7b15f8178bc1cac97f3b8935394b3/mozilla-try-scripts/gecko-try.sh

deploy: gecko-1-b-win2012 gecko-2-b-win2012 gecko-3-b-win2012 gecko-t-win10-64-gpu gecko-t-win10-64 gecko-t-win7-32-gpu gecko-t-win7-32