### PR TITLE
Deploy generic-worker 16.4.0 to production

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -606,9 +606,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -707,7 +707,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -606,9 +606,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -707,7 +707,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -873,9 +873,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "b6fc9df9db5ee7fbdb9a6df7b05dba5405c5dc78e94e5fdfdb32fa745b19afd83f094dfe389665af304aa7ecb6aa7f453d379a0f84ee5147fa6a518c78423fd1"
+      "sha512": "2379ece2522ba98f63ee7f3d4252f4d881c2b3ff20f93e46e9daa2b0d5921bfee7f918c646c5adf9792e573455726156f815738c6feab43b318cec437e9d954a"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -974,7 +974,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -874,9 +874,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "b6fc9df9db5ee7fbdb9a6df7b05dba5405c5dc78e94e5fdfdb32fa745b19afd83f094dfe389665af304aa7ecb6aa7f453d379a0f84ee5147fa6a518c78423fd1"
+      "sha512": "2379ece2522ba98f63ee7f3d4252f4d881c2b3ff20f93e46e9daa2b0d5921bfee7f918c646c5adf9792e573455726156f815738c6feab43b318cec437e9d954a"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -975,7 +975,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.4.0 *"
           }
         ]
       }


### PR DESCRIPTION
See [bug 1588834](https://bugzil.la/1588834) for context.

Successful try push [here](https://treeherder.mozilla.org/#/jobs?repo=try&revision=005a0149b0fd86129434292d7be5153048af2e05&group_state=expanded).

Commit made with:

    ./gecko-try.sh -p -b bug1588834 16.4.0 5.1.0

See https://github.com/taskcluster/generic-worker/blob/v16.4.0/mozilla-try-scripts/gecko-try.sh