### PR TITLE
Upgrade to generic-worker 16.5.1 / taskcluster-proxy 5.1.0.

### DIFF
--- a/userdata/Manifest/gecko-1-b-win2012-xlarge.json
+++ b/userdata/Manifest/gecko-1-b-win2012-xlarge.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-1-b-win2012.json
+++ b/userdata/Manifest/gecko-1-b-win2012.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-2-b-win2012.json
+++ b/userdata/Manifest/gecko-2-b-win2012.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-3-b-win2012.json
+++ b/userdata/Manifest/gecko-3-b-win2012.json
@@ -1131,9 +1131,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1232,7 +1232,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu-s.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu-s.json
@@ -606,9 +606,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v15.1.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "bf279cd911b71d3c173e8988e8b0c091310df968e087c36c9c013eec3b1eafdbf0f5e3e65e69307fc2b66a62b69355b77ce9e9137577b7ece95dc7bbc56d9107"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -707,7 +707,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 15.1.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64-gpu.json
+++ b/userdata/Manifest/gecko-t-win10-64-gpu.json
@@ -606,9 +606,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -707,7 +707,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win10-64.json
+++ b/userdata/Manifest/gecko-t-win10-64.json
@@ -606,9 +606,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "450ac98c6238bccf7b6df91a999b874601ee7f4d1d50d9d828d858845cacca27ea06856b087076cf218b088308b6e0f53a59f8a2fb0275841ba43233627b6261"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -707,7 +707,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32-gpu.json
+++ b/userdata/Manifest/gecko-t-win7-32-gpu.json
@@ -873,9 +873,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "2379ece2522ba98f63ee7f3d4252f4d881c2b3ff20f93e46e9daa2b0d5921bfee7f918c646c5adf9792e573455726156f815738c6feab43b318cec437e9d954a"
+      "sha512": "47188fff3177ce7addc2b28850062bfb4aa9ed3d759819ff79c8bbb6384456aa5a3bca2dbeb66af826af6eec66946df0d55c80e142e08aae76ad872ea9aa0aed"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -974,7 +974,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/gecko-t-win7-32.json
+++ b/userdata/Manifest/gecko-t-win7-32.json
@@ -874,9 +874,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.4.0/generic-worker-multiuser-windows-386.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-386.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "2379ece2522ba98f63ee7f3d4252f4d881c2b3ff20f93e46e9daa2b0d5921bfee7f918c646c5adf9792e573455726156f815738c6feab43b318cec437e9d954a"
+      "sha512": "47188fff3177ce7addc2b28850062bfb4aa9ed3d759819ff79c8bbb6384456aa5a3bca2dbeb66af826af6eec66946df0d55c80e142e08aae76ad872ea9aa0aed"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -975,7 +975,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.4.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/mpd001-1-b-win2012.json
+++ b/userdata/Manifest/mpd001-1-b-win2012.json
@@ -1192,9 +1192,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1293,7 +1293,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }

--- a/userdata/Manifest/mpd001-3-b-win2012.json
+++ b/userdata/Manifest/mpd001-3-b-win2012.json
@@ -1192,9 +1192,9 @@
           "ComponentName": "GenericWorkerDirectory"
         }
       ],
-      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.3.0/generic-worker-multiuser-windows-amd64.exe",
+      "Source": "https://github.com/taskcluster/generic-worker/releases/download/v16.5.1/generic-worker-multiuser-windows-amd64.exe",
       "Target": "C:\\generic-worker\\generic-worker.exe",
-      "sha512": "373bc14f9945ff1590b7e5650ad5c5b71bf40759dbe02f22950c86a8dae029273431bfda49f2dffe4a16e6f2edfff3652c4cc3918cf79cd50d1096bab03af5fa"
+      "sha512": "a2c24dcfe113d1fc947eac4b7762aba1f7ffb25fcb39502b5400cfae8dafb8c20f3f129df1bbc0eadaea98d5af62210a88f58c0a00eccc5eaf15c8bf29f454ec"
     },
     {
       "ComponentName": "LiveLogDownload",
@@ -1293,7 +1293,7 @@
             "Arguments": [
               "--version"
             ],
-            "Like": "generic-worker (multiuser engine) 16.3.0 *"
+            "Like": "generic-worker (multiuser engine) 16.5.1 *"
           }
         ]
       }


### PR DESCRIPTION
This change updates worker types:
  gecko-1-b-win2012-xlarge gecko-1-b-win2012 gecko-2-b-win2012 gecko-3-b-win2012 gecko-t-win10-64-gpu-s gecko-t-win10-64-gpu gecko-t-win10-64 gecko-t-win7-32-gpu gecko-t-win7-32 mpd001-1-b-win2012 mpd001-3-b-win2012

Commit made with:
    ./push-to-occ.sh -p -b bug1591769 16.5.1 5.1.0

See https://github.com/taskcluster/generic-worker/blob/48d34c3e0d4f0360c965fad5365659273d423e93/mozilla-try-scripts/push-to-occ.sh

Note, try push is [here](https://treeherder.mozilla.org/#/jobs?repo=try&revision=9f0a35a52d9321513a9a7b2515fcc39e08070629&group_state=expanded). The commit message is misleading, since it says it tests 16.5.0, but since 16.5.0 didn't start up, the tasks actually ran once 16.5.1 was deployed, so it is testing 16.5.1 after all. This can be verified by looking at the task log of any task and looking at the first few lines which log the generic-worker version number and commit SHA.

See [bug 1591769](https://bugzil.la/1591769) for more details about the start up failure that this release fixes.

Generic worker 16.5.1 release notes [here](https://github.com/taskcluster/generic-worker#in-v1651-since-v1650).