### PR TITLE
Set image-specific worker config via worker runner.

### DIFF
--- a/userdata/Configuration/GenericWorker/worker-runner-azure.yaml
+++ b/userdata/Configuration/GenericWorker/worker-runner-azure.yaml
@@ -5,4 +5,22 @@ worker:
   service: GenericWorker
   configPath: C:\generic-worker\generic-worker-config.yml
   protocolPipe: \\.\pipe\generic-worker
+workerConfig:
+  'cachesDir': 'Z:\\caches'
+  'cleanUpTaskDirs': true
+  'disableReboots': true
+  'downloadsDir': 'Z:\\downloads'
+  'ed25519SigningKeyLocation': 'C:\\generic-worker\\ed25519-private.key'
+  'livelogExecutable': 'C:\\generic-worker\\livelog.exe'
+  'livelogPUTPort': 60022
+  'numberOfTasksToRun': 0
+  'runAfterUserCreation': 'C:\\generic-worker\\task-user-init.cmd'
+  'runTasksAsCurrentUser': false
+  'sentryProject': 'generic-worker'
+  'shutdownMachineOnIdle': false
+  'shutdownMachineOnInternalError': true
+  'taskclusterProxyExecutable': 'C:\\generic-worker\\taskcluster-proxy.exe'
+  'taskclusterProxyPort': 80
+  'tasksDir': 'Z:\\'
+
 cacheOverRestarts: C:\generic-worker\worker-runner-cache.json


### PR DESCRIPTION
There is a bunch of configuration that is specific to how the image is configured. Set that configuration in the image as well, rather than requiring it to be carried around elsewhere.