### PR TITLE
Bug 1405083 - Supress firewall notifications

### DIFF
--- a/userdata/Configuration/GenericWorker/run-hw-generic-worker-10-and-reboot.bat
+++ b/userdata/Configuration/GenericWorker/run-hw-generic-worker-10-and-reboot.bat
@@ -55,6 +55,11 @@ goto CheckForStateFlag
 ping -n 2 127.0.0.1 1>/nul
 goto CheckForStateFlag
 
+rem Supressing firewall warnings. Current user needs to be fully logged in.
+rem not an ideal place for this, but it works as needed
+rem https://bugzilla.mozilla.org/show_bug.cgi?id=1405083
+netsh firewall set notifications mode = disable profile = all
+
 :RunWorker
 echo File C:\dsc\task-claim-state.valid found >> C:\generic-worker\generic-worker-wrapper.log
 echo Deleting C:\dsc\task-claim-state.valid file >> C:\generic-worker\generic-worker-wrapper.log

--- a/userdata/OCC-Bootstrap.psm1
+++ b/userdata/OCC-Bootstrap.psm1
@@ -2735,6 +2735,12 @@ function Invoke-OpenCloudConfig {
       } else {
         Set-ChainOfTrustKey -locationType $locationType -workerType $workerType -shutdown:$false
       }
+      # Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=1405083
+      # Specificly for Yogas. Not ideal but should work   
+      if (${env:PROCESSOR_ARCHITEW6432} -eq 'ARM64') {
+        $network = ((Get-NetConnectionProfile).name)
+        Set-NetConnectionProfile -Name "$network" -NetworkCategory Private
+      }
       Wait-GenericWorkerStart -locationType $locationType -lock $lock
     }
     if (Test-Path -Path $lock -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
This isn't ideal but will prevent the firewall notification on Yogas. Which is currently breaking tests. 

Rob, could you test this on your Yoga? For some reason I have never been able to get OCC to run on mine. 